### PR TITLE
chore(env): update .env.example and build-func.mjs for Vercel compati…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,12 @@
 # Postgres
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/crm?schema=public"
 
+# A direct, unpooled connection to that same database, used by
+# `prisma migrate deploy` when the API is built on Vercel. Set it only if
+# DATABASE_URL points at a pooler; POSTGRES_URL_NON_POOLING is read as a
+# fallback. Locally there is nothing to set.
+# DIRECT_DATABASE_URL=""
+
 # Generate your own:  openssl rand -base64 32
 BETTER_AUTH_SECRET=""
 

--- a/apps/agent/turbo.json
+++ b/apps/agent/turbo.json
@@ -4,7 +4,7 @@
 	"tasks": {
 		"build": {
 			"dependsOn": ["^build"],
-			"outputs": [".eve/**"]
+			"outputs": [".eve/**", ".output/**", ".vercel/output/**"]
 		},
 		"check-types": {
 			"dependsOn": ["topo", "^build"]

--- a/apps/api/scripts/build-func.mjs
+++ b/apps/api/scripts/build-func.mjs
@@ -163,3 +163,24 @@ writeFileSync(
 );
 
 console.log(`✓ built ${outDir}`);
+
+const directDatabaseUrl = !process.env.VERCEL
+	? undefined
+	: process.env.DIRECT_DATABASE_URL ||
+		process.env.POSTGRES_URL_NON_POOLING ||
+		process.env.DATABASE_URL_UNPOOLED ||
+		process.env.DATABASE_URL;
+
+if (!process.env.VERCEL) {
+	console.log("• not a Vercel build — skipping migrations");
+} else if (!directDatabaseUrl) {
+	console.log("• no database URL at build time — skipping migrations");
+} else {
+	console.log("• applying migrations (prisma migrate deploy)...");
+	execSync(`${bun} x prisma migrate deploy`, {
+		cwd: join(repoRoot, "packages/db"),
+		stdio: "inherit",
+		env: { ...process.env, DATABASE_URL: directDatabaseUrl },
+	});
+	console.log("✓ migrations applied");
+}

--- a/apps/app/app/(app)/settings/agent-model.tsx
+++ b/apps/app/app/(app)/settings/agent-model.tsx
@@ -94,9 +94,11 @@ export function AgentModel() {
 	const defaultModel = models.find((model) => model.id === defaultId);
 	const current = selectedId ?? FOLLOW_DEFAULT;
 
+	const effectiveName = effective?.name ?? effectiveId;
+
 	const currentLabel = selectedId
-		? (effective?.name ?? selectedId)
-		: `Default — ${defaultModel?.name ?? defaultId}`;
+		? effectiveName
+		: `Default — ${effectiveName}`;
 
 	const choose = (id: string) => {
 		setOpen(false);

--- a/apps/app/app/(app)/settings/page.tsx
+++ b/apps/app/app/(app)/settings/page.tsx
@@ -26,9 +26,8 @@ export default async function SettingsPage() {
 	await Promise.all([
 		queryClient.prefetchQuery(trpc.google.status.queryOptions()),
 		queryClient.prefetchQuery(trpc.settings.agentModel.queryOptions()),
+		queryClient.prefetchQuery(trpc.settings.modelCatalog.queryOptions()),
 	]);
-
-	void queryClient.prefetchQuery(trpc.settings.modelCatalog.queryOptions());
 
 	return (
 		<PageShell>

--- a/packages/auth/src/client.ts
+++ b/packages/auth/src/client.ts
@@ -1,7 +1,7 @@
 import { createAuthClient } from "better-auth/react";
 
 export const authClient = createAuthClient({
-	baseURL: process.env.NEXT_PUBLIC_API_URL,
+	baseURL: typeof window === "undefined" ? undefined : window.location.origin,
 });
 
 export const { getSession, signIn, signOut, useSession } = authClient;


### PR DESCRIPTION
…bility

- Added documentation for DIRECT_DATABASE_URL in .env.example to clarify its purpose for Vercel deployments.
- Enhanced build-func.mjs to conditionally apply database migrations based on the presence of a direct database URL during Vercel builds.
- Improved agent-model.tsx to simplify the currentLabel logic using effectiveName.
- Updated page.tsx to streamline prefetching of model catalog data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Vercel builds safer by documenting `DIRECT_DATABASE_URL` and running `prisma migrate deploy` only when a direct DB URL is present. Also tidied up model settings prefetch, switched the auth client to use the browser origin, and updated Turbo outputs for Vercel.

- **Refactors**
  - `.env.example`: Documented `DIRECT_DATABASE_URL` for Vercel deployments and non-pooled connections.
  - `apps/api/scripts/build-func.mjs`: Conditionally runs migrations on Vercel; env fallback order: `DIRECT_DATABASE_URL` → `POSTGRES_URL_NON_POOLING` → `DATABASE_URL_UNPOOLED` → `DATABASE_URL`.
  - `apps/agent/turbo.json`: Added `.output/**` and `.vercel/output/**` to `build` outputs.
  - Settings: Simplified label logic in `agent-model.tsx`; prefetch `modelCatalog` in `Promise.all` on `page.tsx`.
  - Auth: `better-auth` client `baseURL` now uses `window.location.origin` in the browser (undefined on server).

- **Migration**
  - On Vercel, set a direct, unpooled DB URL via `DIRECT_DATABASE_URL` (or `POSTGRES_URL_NON_POOLING` / `DATABASE_URL_UNPOOLED`) so build-time migrations can run.

<sup>Written for commit 0caf6159c2e43c28aae8b5df080d71739e12c658. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

