### PR TITLE
docs: create env before installing dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ issue.
 Everything you need is in the [README](./README.md#quick-start). Short version:
 
 ```sh
+cp .env.example .env      # fill in ALLOWED_SIGN_IN and the two Google values
 bun install
 docker compose up -d
-cp .env.example .env      # fill in ALLOWED_SIGN_IN and the two Google values
 bun run db:deploy && bun run db:seed
 bun run dev
 ```

--- a/README.md
+++ b/README.md
@@ -208,10 +208,10 @@ You need [Bun](https://bun.com) and Docker.
 
 ```sh
 git clone https://github.com/trycompai/crm.git && cd crm
+cp .env.example .env          # then fill in the four values below
 bun install
 
 docker compose up -d          # Postgres on :5432
-cp .env.example .env          # then fill in the four values below
 
 bun run db:deploy             # apply migrations
 bun run db:seed               # optional: a believable pipeline to look at


### PR DESCRIPTION
## Summary

- create the root `.env` before running `bun install` in the README quick start
- keep the shorter setup sequence in `CONTRIBUTING.md` consistent

## Why

The `@crm/db` postinstall script loads Prisma configuration during `bun install`. Without a root `.env`, Prisma cannot resolve `DATABASE_URL`, so a fresh clone fails before reaching the documented environment setup step.

## User impact

New contributors can follow the setup instructions in order without the dependency installation failing on a missing `DATABASE_URL`.

## Validation

- `git diff --check`
- structured pre-ship review: clean, no actionable findings
- reproduced that `bun install` fails before `.env` exists and succeeds after copying `.env.example`

Closes #6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Create the root `.env` before running `bun install` in Quick Start and CONTRIBUTING. This prevents `@crm/db`’s postinstall from failing when Prisma can’t find `DATABASE_URL` on a fresh clone.

<sup>Written for commit 83755fbfc7b3f6032107b13b3c9af0ccbb62cd69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

