### PR TITLE
feat(api): implement delete functionality for companies, contacts, an…

### DIFF
--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -1,6 +1,7 @@
+import { AUTH_COOKIE_PREFIX } from "@crm/auth/cookies";
 import { db } from "@crm/db";
 
-const COOKIE_NAME = "better-auth.session_token";
+const COOKIE_NAME = `${AUTH_COOKIE_PREFIX}.session_token`;
 const SESSION_DAYS = 7;
 
 if (process.env.NODE_ENV === "production") {

--- a/apps/api/src/companies/companies.router.ts
+++ b/apps/api/src/companies/companies.router.ts
@@ -53,6 +53,11 @@ export class CompaniesRouter {
 	}
 
 	@Mutation({ input: companyIdInput })
+	async delete(@Input("id") id: string) {
+		return this.companies.delete(id);
+	}
+
+	@Mutation({ input: companyIdInput })
 	async enrich(@Input("id") id: string) {
 		return this.companies.enrich(id);
 	}

--- a/apps/api/src/companies/companies.service.ts
+++ b/apps/api/src/companies/companies.service.ts
@@ -377,12 +377,16 @@ export class CompaniesService {
 			throw new NotFoundException(`No company with id ${id}.`);
 		}
 
-		await this.db.$transaction([
-			this.db.agentTask.deleteMany({ where: { companyId: id } }),
-			this.db.company.delete({ where: { id } }),
-		]);
+		try {
+			await this.db.$transaction([
+				this.db.agentTask.deleteMany({ where: { companyId: id } }),
+				this.db.company.delete({ where: { id } }),
+			]);
+		} catch (error) {
+			throw this.translate(error, id);
+		}
 
-		await this.stamp.recomputeAll();
+		await this.stamp.recomputeAllAfterDelete({ companyId: id });
 
 		this.logger.log({
 			message: "Company deleted",

--- a/apps/api/src/companies/companies.service.ts
+++ b/apps/api/src/companies/companies.service.ts
@@ -14,7 +14,10 @@ import {
 } from "@nestjs/common";
 import { AgentQueueService } from "../agent/agent-queue.service";
 import { AgentTriggerService } from "../agent/agent-trigger.service";
-import { ActivityStampService } from "../crm/activity-stamp.service";
+import {
+	ActivityStampService,
+	type StampTargets,
+} from "../crm/activity-stamp.service";
 import { blankToNull, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import { OPEN_DEAL_STAGES } from "../deals/deal-stage";
@@ -368,33 +371,37 @@ export class CompaniesService {
 	}
 
 	async delete(id: string): Promise<{ id: string; name: string }> {
-		const company = await this.db.company.findUnique({
-			where: { id },
-			select: { id: true, name: true },
-		});
-
-		if (!company) {
-			throw new NotFoundException(`No company with id ${id}.`);
-		}
+		let deleted: { targets: StampTargets; name: string };
 
 		try {
-			await this.db.$transaction([
-				this.db.agentTask.deleteMany({ where: { companyId: id } }),
-				this.db.company.delete({ where: { id } }),
-			]);
+			deleted = await this.db.$transaction(async (tx) => {
+				const targets = await this.stamp.targetsOf(
+					{ OR: [{ companyId: id }, { deal: { companyId: id } }] },
+					tx,
+				);
+
+				await tx.agentTask.deleteMany({ where: { companyId: id } });
+
+				const company = await tx.company.delete({
+					where: { id },
+					select: { name: true },
+				});
+
+				return { targets, name: company.name };
+			});
 		} catch (error) {
 			throw this.translate(error, id);
 		}
 
-		await this.stamp.recomputeAllAfterDelete({ companyId: id });
+		await this.stamp.recomputeAfterDelete(deleted.targets, { companyId: id });
 
 		this.logger.log({
 			message: "Company deleted",
 			companyId: id,
-			name: company.name,
+			name: deleted.name,
 		});
 
-		return company;
+		return { id, name: deleted.name };
 	}
 
 	async enrich(id: string): Promise<{ id: string; queued: boolean }> {

--- a/apps/api/src/companies/companies.service.ts
+++ b/apps/api/src/companies/companies.service.ts
@@ -14,6 +14,7 @@ import {
 } from "@nestjs/common";
 import { AgentQueueService } from "../agent/agent-queue.service";
 import { AgentTriggerService } from "../agent/agent-trigger.service";
+import { ActivityStampService } from "../crm/activity-stamp.service";
 import { blankToNull, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import { OPEN_DEAL_STAGES } from "../deals/deal-stage";
@@ -89,6 +90,7 @@ export class CompaniesService {
 		private readonly agent: AgentTriggerService,
 		private readonly queue: AgentQueueService,
 		private readonly favicon: FaviconService,
+		private readonly stamp: ActivityStampService,
 	) {}
 
 	async list(input: CompanyListInput): Promise<ListResult<CompanyRow>> {
@@ -363,6 +365,32 @@ export class CompaniesService {
 		} catch (error) {
 			throw this.translate(error, id);
 		}
+	}
+
+	async delete(id: string): Promise<{ id: string; name: string }> {
+		const company = await this.db.company.findUnique({
+			where: { id },
+			select: { id: true, name: true },
+		});
+
+		if (!company) {
+			throw new NotFoundException(`No company with id ${id}.`);
+		}
+
+		await this.db.$transaction([
+			this.db.agentTask.deleteMany({ where: { companyId: id } }),
+			this.db.company.delete({ where: { id } }),
+		]);
+
+		await this.stamp.recomputeAll();
+
+		this.logger.log({
+			message: "Company deleted",
+			companyId: id,
+			name: company.name,
+		});
+
+		return company;
 	}
 
 	async enrich(id: string): Promise<{ id: string; queued: boolean }> {

--- a/apps/api/src/companies/domain.ts
+++ b/apps/api/src/companies/domain.ts
@@ -26,7 +26,20 @@ export function domainFromEmail(
 	const at = email?.trim().toLowerCase().lastIndexOf("@") ?? -1;
 	if (at < 1) return null;
 	const domain = normalizeDomain(email?.slice(at + 1));
-	return domain && !FREE_EMAIL_DOMAINS.has(domain) ? domain : null;
+	if (!domain) return null;
+	return FREE_EMAIL_DOMAINS.has(domain) || isMachineDomain(domain)
+		? null
+		: domain;
+}
+
+export function isMachineDomain(input: string | null | undefined): boolean {
+	const domain = normalizeDomain(input);
+	if (!domain) return false;
+
+	return (
+		MACHINE_DOMAINS.has(domain) ||
+		MACHINE_SUFFIXES.some((suffix) => domain.endsWith(suffix))
+	);
 }
 
 const FREE_EMAIL_DOMAINS = new Set([
@@ -52,3 +65,25 @@ const FREE_EMAIL_DOMAINS = new Set([
 	"qq.com",
 	"163.com",
 ]);
+
+const MACHINE_DOMAINS = new Set([
+	"calendar.google.com",
+	"googlegroups.com",
+	"docs.google.com",
+	"drive.google.com",
+	"appspotmail.com",
+	"amazonses.com",
+	"sendgrid.net",
+	"zoomcrc.com",
+]);
+
+const MACHINE_SUFFIXES = [
+	".calendar.google.com",
+	".bounces.google.com",
+	".appspotmail.com",
+	".amazonses.com",
+	".sendgrid.net",
+	".invalid",
+	".local",
+	".localhost",
+];

--- a/apps/api/src/contacts/contacts.router.ts
+++ b/apps/api/src/contacts/contacts.router.ts
@@ -47,6 +47,11 @@ export class ContactsRouter {
 	}
 
 	@Mutation({ input: contactIdInput })
+	async delete(@Input("id") id: string) {
+		return this.contacts.delete(id);
+	}
+
+	@Mutation({ input: contactIdInput })
 	async enrich(@Input("id") id: string) {
 		return this.contacts.enrich(id);
 	}

--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -17,7 +17,7 @@ import { AgentQueueService } from "../agent/agent-queue.service";
 import { AgentTriggerService } from "../agent/agent-trigger.service";
 import { CompanyDirectoryService } from "../companies/company-directory.service";
 import { ActivityStampService } from "../crm/activity-stamp.service";
-import { blankToNull, toCents } from "../crm/values";
+import { blankToNull, normalizeEmail, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import {
 	countsByKey,
@@ -257,11 +257,11 @@ export class ContactsService {
 	}
 
 	async create(input: ContactCreateInput) {
-		const email = blankToNull(input.email ?? "");
+		const email = normalizeEmail(input.email ?? "");
 
 		if (email) {
-			const existing = await this.db.contact.findUnique({
-				where: { email },
+			const existing = await this.db.contact.findFirst({
+				where: { email: { equals: email, mode: "insensitive" } },
 				select: { id: true, firstName: true, lastName: true },
 			});
 			if (existing) {
@@ -279,20 +279,22 @@ export class ContactsService {
 					})
 				: null);
 
-		const contact = await this.db.contact.create({
-			data: {
-				firstName: input.firstName.trim(),
-				lastName: blankToNull(input.lastName ?? ""),
-				email,
-				phone: blankToNull(input.phone ?? ""),
-				title: blankToNull(input.title ?? ""),
-				companyId,
-				ownerId: input.ownerId ?? null,
-			},
-			select: { id: true, firstName: true, lastName: true },
-		});
+		const contact = await this.db.$transaction(async (tx) => {
+			await this.allowAgain(tx, email);
 
-		await this.allowAgain(email);
+			return tx.contact.create({
+				data: {
+					firstName: input.firstName.trim(),
+					lastName: blankToNull(input.lastName ?? ""),
+					email,
+					phone: blankToNull(input.phone ?? ""),
+					title: blankToNull(input.title ?? ""),
+					companyId,
+					ownerId: input.ownerId ?? null,
+				},
+				select: { id: true, firstName: true, lastName: true },
+			});
+		});
 
 		this.logger.log({ message: "Contact created", contactId: contact.id });
 
@@ -318,30 +320,36 @@ export class ContactsService {
 			.filter(Boolean)
 			.join(" ");
 
-		await this.db.$transaction([
-			...(contact.email
-				? [
-						this.db.suppressedContact.upsert({
-							where: { email: contact.email },
-							create: {
-								email: contact.email,
-								reason: `Deleted from the CRM (${name})`,
-							},
-							update: {},
-						}),
-					]
-				: []),
-			this.db.agentTask.deleteMany({ where: { contactId: id } }),
-			this.db.agentEvent.deleteMany({ where: { contactId: id } }),
-			this.db.contact.delete({ where: { id } }),
-		]);
+		const suppress = normalizeEmail(contact.email ?? "");
 
-		await this.stamp.recomputeAll();
+		try {
+			await this.db.$transaction([
+				...(suppress
+					? [
+							this.db.suppressedContact.upsert({
+								where: { email: suppress },
+								create: {
+									email: suppress,
+									reason: `Deleted from the CRM (${name})`,
+								},
+								update: {},
+							}),
+						]
+					: []),
+				this.db.agentTask.deleteMany({ where: { contactId: id } }),
+				this.db.agentEvent.deleteMany({ where: { contactId: id } }),
+				this.db.contact.delete({ where: { id } }),
+			]);
+		} catch (error) {
+			throw this.translate(error, id);
+		}
+
+		await this.stamp.recomputeAllAfterDelete({ contactId: id });
 
 		this.logger.log({
 			message: "Contact deleted",
 			contactId: id,
-			suppressed: contact.email !== null,
+			suppressed: suppress !== null,
 		});
 
 		return { id, name };
@@ -353,7 +361,7 @@ export class ContactsService {
 		if (input.firstName !== undefined) data.firstName = input.firstName.trim();
 		if (input.lastName !== undefined)
 			data.lastName = blankToNull(input.lastName);
-		if (input.email !== undefined) data.email = blankToNull(input.email);
+		if (input.email !== undefined) data.email = normalizeEmail(input.email);
 		if (input.phone !== undefined) data.phone = blankToNull(input.phone);
 		if (input.title !== undefined) data.title = blankToNull(input.title);
 		if (input.linkedinUrl !== undefined) {
@@ -377,23 +385,32 @@ export class ContactsService {
 		}
 
 		try {
-			const updated = await this.db.contact.update({
-				where: { id },
-				data,
-				select: { id: true, firstName: true, lastName: true },
+			return await this.db.$transaction(async (tx) => {
+				const updated = await tx.contact.update({
+					where: { id },
+					data,
+					select: { id: true, firstName: true, lastName: true },
+				});
+
+				if (typeof data.email === "string") {
+					await this.allowAgain(tx, data.email);
+				}
+
+				return updated;
 			});
-
-			if (typeof data.email === "string") await this.allowAgain(data.email);
-
-			return updated;
 		} catch (error) {
 			throw this.translate(error, id);
 		}
 	}
 
-	private async allowAgain(email: string | null): Promise<void> {
+	private async allowAgain(
+		tx: Prisma.TransactionClient,
+		email: string | null,
+	): Promise<void> {
 		if (!email) return;
-		await this.db.suppressedContact.deleteMany({ where: { email } });
+		await tx.suppressedContact.deleteMany({
+			where: { email: { equals: email, mode: "insensitive" } },
+		});
 	}
 
 	private async relationship(contactId: string, companyId: string | null) {

--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -16,6 +16,7 @@ import {
 import { AgentQueueService } from "../agent/agent-queue.service";
 import { AgentTriggerService } from "../agent/agent-trigger.service";
 import { CompanyDirectoryService } from "../companies/company-directory.service";
+import { ActivityStampService } from "../crm/activity-stamp.service";
 import { blankToNull, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import {
@@ -108,6 +109,7 @@ export class ContactsService {
 		private readonly companies: CompanyDirectoryService,
 		private readonly agent: AgentTriggerService,
 		private readonly queue: AgentQueueService,
+		private readonly stamp: ActivityStampService,
 	) {}
 
 	async list(input: ContactListInput): Promise<ListResult<ContactRow>> {
@@ -290,6 +292,8 @@ export class ContactsService {
 			select: { id: true, firstName: true, lastName: true },
 		});
 
+		await this.allowAgain(email);
+
 		this.logger.log({ message: "Contact created", contactId: contact.id });
 
 		await this.agent.contactCreated(
@@ -298,6 +302,49 @@ export class ContactsService {
 		);
 
 		return contact;
+	}
+
+	async delete(id: string): Promise<{ id: string; name: string }> {
+		const contact = await this.db.contact.findUnique({
+			where: { id },
+			select: { id: true, firstName: true, lastName: true, email: true },
+		});
+
+		if (!contact) {
+			throw new NotFoundException(`No contact with id ${id}.`);
+		}
+
+		const name = [contact.firstName, contact.lastName]
+			.filter(Boolean)
+			.join(" ");
+
+		await this.db.$transaction([
+			...(contact.email
+				? [
+						this.db.suppressedContact.upsert({
+							where: { email: contact.email },
+							create: {
+								email: contact.email,
+								reason: `Deleted from the CRM (${name})`,
+							},
+							update: {},
+						}),
+					]
+				: []),
+			this.db.agentTask.deleteMany({ where: { contactId: id } }),
+			this.db.agentEvent.deleteMany({ where: { contactId: id } }),
+			this.db.contact.delete({ where: { id } }),
+		]);
+
+		await this.stamp.recomputeAll();
+
+		this.logger.log({
+			message: "Contact deleted",
+			contactId: id,
+			suppressed: contact.email !== null,
+		});
+
+		return { id, name };
 	}
 
 	async update(id: string, input: ContactUpdateInput) {
@@ -330,14 +377,23 @@ export class ContactsService {
 		}
 
 		try {
-			return await this.db.contact.update({
+			const updated = await this.db.contact.update({
 				where: { id },
 				data,
 				select: { id: true, firstName: true, lastName: true },
 			});
+
+			if (typeof data.email === "string") await this.allowAgain(data.email);
+
+			return updated;
 		} catch (error) {
 			throw this.translate(error, id);
 		}
+	}
+
+	private async allowAgain(email: string | null): Promise<void> {
+		if (!email) return;
+		await this.db.suppressedContact.deleteMany({ where: { email } });
 	}
 
 	private async relationship(contactId: string, companyId: string | null) {

--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -16,7 +16,10 @@ import {
 import { AgentQueueService } from "../agent/agent-queue.service";
 import { AgentTriggerService } from "../agent/agent-trigger.service";
 import { CompanyDirectoryService } from "../companies/company-directory.service";
-import { ActivityStampService } from "../crm/activity-stamp.service";
+import {
+	ActivityStampService,
+	type StampTargets,
+} from "../crm/activity-stamp.service";
 import { blankToNull, normalizeEmail, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import {
@@ -307,52 +310,55 @@ export class ContactsService {
 	}
 
 	async delete(id: string): Promise<{ id: string; name: string }> {
-		const contact = await this.db.contact.findUnique({
-			where: { id },
-			select: { id: true, firstName: true, lastName: true, email: true },
-		});
-
-		if (!contact) {
-			throw new NotFoundException(`No contact with id ${id}.`);
-		}
-
-		const name = [contact.firstName, contact.lastName]
-			.filter(Boolean)
-			.join(" ");
-
-		const suppress = normalizeEmail(contact.email ?? "");
+		let deleted: {
+			targets: StampTargets;
+			name: string;
+			suppressed: boolean;
+		};
 
 		try {
-			await this.db.$transaction([
-				...(suppress
-					? [
-							this.db.suppressedContact.upsert({
-								where: { email: suppress },
-								create: {
-									email: suppress,
-									reason: `Deleted from the CRM (${name})`,
-								},
-								update: {},
-							}),
-						]
-					: []),
-				this.db.agentTask.deleteMany({ where: { contactId: id } }),
-				this.db.agentEvent.deleteMany({ where: { contactId: id } }),
-				this.db.contact.delete({ where: { id } }),
-			]);
+			deleted = await this.db.$transaction(async (tx) => {
+				const targets = await this.stamp.targetsOf({ contactId: id }, tx);
+
+				await tx.agentTask.deleteMany({ where: { contactId: id } });
+				await tx.agentEvent.deleteMany({ where: { contactId: id } });
+
+				const contact = await tx.contact.delete({
+					where: { id },
+					select: { firstName: true, lastName: true, email: true },
+				});
+
+				const name = [contact.firstName, contact.lastName]
+					.filter(Boolean)
+					.join(" ");
+				const suppress = normalizeEmail(contact.email ?? "");
+
+				if (suppress) {
+					await tx.suppressedContact.upsert({
+						where: { email: suppress },
+						create: {
+							email: suppress,
+							reason: `Deleted from the CRM (${name})`,
+						},
+						update: {},
+					});
+				}
+
+				return { targets, name, suppressed: suppress !== null };
+			});
 		} catch (error) {
 			throw this.translate(error, id);
 		}
 
-		await this.stamp.recomputeAllAfterDelete({ contactId: id });
+		await this.stamp.recomputeAfterDelete(deleted.targets, { contactId: id });
 
 		this.logger.log({
 			message: "Contact deleted",
 			contactId: id,
-			suppressed: suppress !== null,
+			suppressed: deleted.suppressed,
 		});
 
-		return { id, name };
+		return { id, name: deleted.name };
 	}
 
 	async update(id: string, input: ContactUpdateInput) {

--- a/apps/api/src/crm/activity-stamp.service.ts
+++ b/apps/api/src/crm/activity-stamp.service.ts
@@ -1,4 +1,4 @@
-import type { Db } from "@crm/db";
+import { type Db, type Prisma, Prisma as PrismaNamespace } from "@crm/db";
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectDatabase } from "../database/database.constants";
 
@@ -7,6 +7,16 @@ export type ActivityTarget = {
 	contactId?: string | null;
 	dealId?: string | null;
 };
+
+export type StampTargets = {
+	companyIds: string[];
+	contactIds: string[];
+	dealIds: string[];
+};
+
+function present(ids: (string | null)[]): string[] {
+	return ids.filter((id): id is string => id !== null);
+}
 
 @Injectable()
 export class ActivityStampService {
@@ -76,9 +86,41 @@ export class ActivityStampService {
 		}
 	}
 
-	async recomputeAllAfterDelete(deleted: ActivityTarget): Promise<void> {
+	async targetsOf(
+		where: Prisma.ActivityWhereInput,
+		client: Prisma.TransactionClient = this.db,
+	): Promise<StampTargets> {
+		const [companies, contacts, deals] = await Promise.all([
+			client.activity.groupBy({ by: ["companyId"], where }),
+			client.activity.groupBy({ by: ["contactId"], where }),
+			client.activity.groupBy({ by: ["dealId"], where }),
+		]);
+
+		return {
+			companyIds: present(companies.map((row) => row.companyId)),
+			contactIds: present(contacts.map((row) => row.contactId)),
+			dealIds: present(deals.map((row) => row.dealId)),
+		};
+	}
+
+	async recomputeMany(targets: StampTargets): Promise<void> {
+		const statements = [
+			this.restamp("company", "companyId", targets.companyIds),
+			this.restamp("contact", "contactId", targets.contactIds),
+			this.restamp("deal", "dealId", targets.dealIds),
+		].filter((statement) => statement !== null);
+
+		if (statements.length === 0) return;
+
+		await this.db.$transaction(statements);
+	}
+
+	async recomputeAfterDelete(
+		targets: StampTargets,
+		deleted: ActivityTarget,
+	): Promise<void> {
 		try {
-			await this.recomputeAll();
+			await this.recomputeMany(targets);
 		} catch (error) {
 			this.logger.error(
 				{
@@ -89,6 +131,20 @@ export class ActivityStampService {
 				error instanceof Error ? error.stack : String(error),
 			);
 		}
+	}
+
+	private restamp(table: string, column: string, ids: string[]) {
+		if (ids.length === 0) return null;
+
+		const record = PrismaNamespace.raw(`"${table}"`);
+		const key = PrismaNamespace.raw(`"${column}"`);
+
+		return this.db.$executeRaw`
+			UPDATE ${record} r
+			SET "lastActivityAt" = (
+				SELECT MAX(a."createdAt") FROM "activity" a WHERE a.${key} = r.id
+			)
+			WHERE r.id IN (${PrismaNamespace.join(ids)})`;
 	}
 
 	async recomputeAll(): Promise<void> {

--- a/apps/api/src/crm/activity-stamp.service.ts
+++ b/apps/api/src/crm/activity-stamp.service.ts
@@ -1,5 +1,5 @@
 import type { Db } from "@crm/db";
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { InjectDatabase } from "../database/database.constants";
 
 export type ActivityTarget = {
@@ -10,6 +10,8 @@ export type ActivityTarget = {
 
 @Injectable()
 export class ActivityStampService {
+	private readonly logger = new Logger(ActivityStampService.name);
+
 	constructor(@InjectDatabase() private readonly db: Db) {}
 
 	async touch(target: ActivityTarget, at: Date): Promise<void> {
@@ -71,6 +73,21 @@ export class ActivityStampService {
 				where: { id: target.dealId },
 				data: { lastActivityAt: _max.createdAt },
 			});
+		}
+	}
+
+	async recomputeAllAfterDelete(deleted: ActivityTarget): Promise<void> {
+		try {
+			await this.recomputeAll();
+		} catch (error) {
+			this.logger.error(
+				{
+					message:
+						"A record was deleted but its activity stamps were not recomputed",
+					...deleted,
+				},
+				error instanceof Error ? error.stack : String(error),
+			);
 		}
 	}
 

--- a/apps/api/src/crm/values.ts
+++ b/apps/api/src/crm/values.ts
@@ -12,3 +12,7 @@ export function blankToNull(value: string): string | null {
 	const trimmed = value.trim();
 	return trimmed === "" ? null : trimmed;
 }
+
+export function normalizeEmail(value: string): string | null {
+	return blankToNull(value)?.toLowerCase() ?? null;
+}

--- a/apps/api/src/deals/deals.router.ts
+++ b/apps/api/src/deals/deals.router.ts
@@ -44,6 +44,11 @@ export class DealsRouter {
 		return this.deals.update(input.id, input.data);
 	}
 
+	@Mutation({ input: dealIdInput })
+	async delete(@Input("id") id: string) {
+		return this.deals.delete(id);
+	}
+
 	@Mutation({ input: setStageInput })
 	async setStage(
 		@Ctx() ctx: AuthedTrpcContext,

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -11,7 +11,10 @@ import {
 	Logger,
 	NotFoundException,
 } from "@nestjs/common";
-import { ActivityStampService } from "../crm/activity-stamp.service";
+import {
+	ActivityStampService,
+	type StampTargets,
+} from "../crm/activity-stamp.service";
 import { fromCents, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
 import {
@@ -245,26 +248,32 @@ export class DealsService {
 	}
 
 	async delete(id: string): Promise<{ id: string; name: string }> {
-		const deal = await this.db.deal.findUnique({
-			where: { id },
-			select: { id: true, name: true },
-		});
-
-		if (!deal) {
-			throw new NotFoundException(`No deal with id ${id}.`);
-		}
+		let deleted: { targets: StampTargets; name: string };
 
 		try {
-			await this.db.deal.delete({ where: { id } });
+			deleted = await this.db.$transaction(async (tx) => {
+				const targets = await this.stamp.targetsOf({ dealId: id }, tx);
+
+				const deal = await tx.deal.delete({
+					where: { id },
+					select: { name: true },
+				});
+
+				return { targets, name: deal.name };
+			});
 		} catch (error) {
 			throw this.translate(error, id);
 		}
 
-		await this.stamp.recomputeAllAfterDelete({ dealId: id });
+		await this.stamp.recomputeAfterDelete(deleted.targets, { dealId: id });
 
-		this.logger.log({ message: "Deal deleted", dealId: id, name: deal.name });
+		this.logger.log({
+			message: "Deal deleted",
+			dealId: id,
+			name: deleted.name,
+		});
 
-		return deal;
+		return { id, name: deleted.name };
 	}
 
 	async setStage(input: SetStageInput, actingUserId: string) {

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -244,6 +244,24 @@ export class DealsService {
 		}
 	}
 
+	async delete(id: string): Promise<{ id: string; name: string }> {
+		const deal = await this.db.deal.findUnique({
+			where: { id },
+			select: { id: true, name: true },
+		});
+
+		if (!deal) {
+			throw new NotFoundException(`No deal with id ${id}.`);
+		}
+
+		await this.db.deal.delete({ where: { id } });
+		await this.stamp.recomputeAll();
+
+		this.logger.log({ message: "Deal deleted", dealId: id, name: deal.name });
+
+		return deal;
+	}
+
 	async setStage(input: SetStageInput, actingUserId: string) {
 		const deal = await this.db.deal.findUnique({
 			where: { id: input.id },

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -254,8 +254,13 @@ export class DealsService {
 			throw new NotFoundException(`No deal with id ${id}.`);
 		}
 
-		await this.db.deal.delete({ where: { id } });
-		await this.stamp.recomputeAll();
+		try {
+			await this.db.deal.delete({ where: { id } });
+		} catch (error) {
+			throw this.translate(error, id);
+		}
+
+		await this.stamp.recomputeAllAfterDelete({ dealId: id });
 
 		this.logger.log({ message: "Deal deleted", dealId: id, name: deal.name });
 

--- a/apps/api/src/generated/server.ts
+++ b/apps/api/src/generated/server.ts
@@ -70,6 +70,9 @@ const appRouter = t.router({
     update: publicProcedure
       .input(companyUpdateArgs)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<CompaniesRouter["update"]>>),
+    delete: publicProcedure
+      .input(companyIdInput)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<CompaniesRouter["delete"]>>),
     enrich: publicProcedure
       .input(companyIdInput)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<CompaniesRouter["enrich"]>>),
@@ -93,6 +96,9 @@ const appRouter = t.router({
     update: publicProcedure
       .input(contactUpdateArgs)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ContactsRouter["update"]>>),
+    delete: publicProcedure
+      .input(contactIdInput)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ContactsRouter["delete"]>>),
     enrich: publicProcedure
       .input(contactIdInput)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<ContactsRouter["enrich"]>>),
@@ -132,6 +138,9 @@ const appRouter = t.router({
     update: publicProcedure
       .input(dealUpdateArgs)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["update"]>>),
+    delete: publicProcedure
+      .input(dealIdInput)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["delete"]>>),
     setStage: publicProcedure
       .input(setStageInput)
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["setStage"]>>)

--- a/apps/api/src/google/calendar-sync.service.ts
+++ b/apps/api/src/google/calendar-sync.service.ts
@@ -17,7 +17,7 @@ import {
 } from "./calendar.client";
 import { GoogleMatchService, type MatchContext } from "./google-match.service";
 import { GoogleTokenService } from "./google-token.service";
-import type { Participant } from "./participants";
+import { isMachineAddress, type Participant } from "./participants";
 import { SyncStateService } from "./sync-state.service";
 
 const MAX_PAGES_PER_TICK = 5;
@@ -294,7 +294,10 @@ export class CalendarSyncService {
 		event: GoogleEvent,
 	): Promise<void> {
 		const attendees = (event.attendees ?? []).filter(
-			(attendee) => attendee.email && !attendee.resource,
+			(attendee) =>
+				attendee.email &&
+				!attendee.resource &&
+				!isMachineAddress(attendee.email.toLowerCase()),
 		);
 
 		if (attendees.length === 0) return;

--- a/apps/api/src/google/calendar-sync.service.ts
+++ b/apps/api/src/google/calendar-sync.service.ts
@@ -71,15 +71,17 @@ export class CalendarSyncService {
 
 		await this.state.markRunning(row.id);
 
-		const [internal, suppressedDomains] = await Promise.all([
+		const [internal, suppressedDomains, suppressedEmails] = await Promise.all([
 			this.match.internalIdentity(),
 			this.match.suppressedDomains(),
+			this.match.suppressedEmails(),
 		]);
 
 		const context = {
 			ourAddresses: internal.addresses,
 			ourDomains: internal.domains,
 			suppressedDomains,
+			suppressedEmails,
 		};
 
 		let pageToken: string | undefined;

--- a/apps/api/src/google/gmail-sync.service.ts
+++ b/apps/api/src/google/gmail-sync.service.ts
@@ -223,15 +223,17 @@ export class GmailSyncService {
 
 		if (batch.length === 0) return { written: 0, remaining };
 
-		const [internal, suppressedDomains] = await Promise.all([
+		const [internal, suppressedDomains, suppressedEmails] = await Promise.all([
 			this.match.internalIdentity(),
 			this.match.suppressedDomains(),
+			this.match.suppressedEmails(),
 		]);
 
 		const context = {
 			ourAddresses: internal.addresses,
 			ourDomains: internal.domains,
 			suppressedDomains,
+			suppressedEmails,
 		};
 
 		let written = 0;

--- a/apps/api/src/google/google-match.service.ts
+++ b/apps/api/src/google/google-match.service.ts
@@ -80,7 +80,7 @@ export class GoogleMatchService {
 		const rows = await this.db.suppressedContact.findMany({
 			select: { email: true },
 		});
-		return new Set(rows.map((row) => row.email));
+		return new Set(rows.map((row) => row.email.toLowerCase()));
 	}
 
 	async resolve(

--- a/apps/api/src/google/google-match.service.ts
+++ b/apps/api/src/google/google-match.service.ts
@@ -28,6 +28,7 @@ export type MatchContext = {
 	ourAddresses: ReadonlySet<string>;
 	ourDomains: ReadonlySet<string>;
 	suppressedDomains: ReadonlySet<string>;
+	suppressedEmails: ReadonlySet<string>;
 };
 
 export type MatchRequest = {
@@ -75,6 +76,13 @@ export class GoogleMatchService {
 		return new Set(rows.map((row) => row.domain));
 	}
 
+	async suppressedEmails(): Promise<Set<string>> {
+		const rows = await this.db.suppressedContact.findMany({
+			select: { email: true },
+		});
+		return new Set(rows.map((row) => row.email));
+	}
+
 	async resolve(
 		request: MatchRequest,
 		context: MatchContext,
@@ -83,6 +91,7 @@ export class GoogleMatchService {
 			ourDomains: context.ourDomains,
 			ourAddresses: context.ourAddresses,
 			suppressedDomains: context.suppressedDomains,
+			suppressedEmails: context.suppressedEmails,
 		});
 
 		if (external.length === 0) {

--- a/apps/api/src/google/participants.ts
+++ b/apps/api/src/google/participants.ts
@@ -1,4 +1,4 @@
-import { domainFromEmail } from "../companies/domain";
+import { domainFromEmail, isMachineDomain } from "../companies/domain";
 
 export type Participant = {
 	email: string;
@@ -104,6 +104,21 @@ export function isAutomatedAddress(email: string): boolean {
 	);
 }
 
+const OPAQUE_LOCAL_PARTS = [
+	/^(c_)?[0-9a-f]{24,}$/,
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+];
+
+export function isMachineAddress(email: string): boolean {
+	const at = email.lastIndexOf("@");
+	if (at < 1) return true;
+
+	if (isMachineDomain(email.slice(at + 1))) return true;
+
+	const local = email.slice(0, at).toLowerCase();
+	return OPAQUE_LOCAL_PARTS.some((pattern) => pattern.test(local));
+}
+
 export function isDerivedName(
 	email: string,
 	firstName: string,
@@ -133,6 +148,7 @@ export function externalParticipants(
 	return participants.filter((participant) => {
 		if (options.ourAddresses.has(participant.email)) return false;
 		if (options.suppressedEmails.has(participant.email)) return false;
+		if (isMachineAddress(participant.email)) return false;
 
 		const domain = workDomain(participant.email);
 		if (!domain) return false;

--- a/apps/api/src/google/participants.ts
+++ b/apps/api/src/google/participants.ts
@@ -123,6 +123,7 @@ export type ExternalFilterOptions = {
 	ourDomains: ReadonlySet<string>;
 	ourAddresses: ReadonlySet<string>;
 	suppressedDomains: ReadonlySet<string>;
+	suppressedEmails: ReadonlySet<string>;
 };
 
 export function externalParticipants(
@@ -131,6 +132,7 @@ export function externalParticipants(
 ): Participant[] {
 	return participants.filter((participant) => {
 		if (options.ourAddresses.has(participant.email)) return false;
+		if (options.suppressedEmails.has(participant.email)) return false;
 
 		const domain = workDomain(participant.email);
 		if (!domain) return false;

--- a/apps/api/test/domain.spec.ts
+++ b/apps/api/test/domain.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { domainFromEmail, normalizeDomain } from "../src/companies/domain";
+import {
+	domainFromEmail,
+	isMachineDomain,
+	normalizeDomain,
+} from "../src/companies/domain";
 
 describe("normalizeDomain", () => {
 	it("reduces anything a human might type to the bare host", () => {
@@ -48,5 +52,24 @@ describe("domainFromEmail", () => {
 		]) {
 			expect(domainFromEmail(email)).toBeNull();
 		}
+	});
+
+	it("never derives a company from infrastructure", () => {
+		for (const email of [
+			"c_f5ecd6a22aea945a2d5c6ac9b8b2b16b@group.calendar.google.com",
+			"list@googlegroups.com",
+			"reply@em1234.amazonses.com",
+		]) {
+			expect(domainFromEmail(email)).toBeNull();
+		}
+	});
+});
+
+describe("isMachineDomain", () => {
+	it("is false for a real host and for nothing", () => {
+		expect(isMachineDomain("stripe.com")).toBe(false);
+		expect(isMachineDomain("calendar.acme.com")).toBe(false);
+		expect(isMachineDomain(null)).toBe(false);
+		expect(isMachineDomain("")).toBe(false);
 	});
 });

--- a/apps/api/test/google-participants.spec.ts
+++ b/apps/api/test/google-participants.spec.ts
@@ -4,6 +4,7 @@ import {
 	externalParticipants,
 	isAutomatedAddress,
 	isDerivedName,
+	isMachineAddress,
 	type Participant,
 	parseAddress,
 	parseAddressList,
@@ -80,6 +81,53 @@ describe("isAutomatedAddress", () => {
 	});
 });
 
+describe("isMachineAddress", () => {
+	it("catches the calendars Google invites as though they were people", () => {
+		for (const email of [
+			"c_f5ecd6a22aea945a2d5c6ac9b8b2b16b@group.calendar.google.com",
+			"acme.com_38dhs2@resource.calendar.google.com",
+			"en.uk#holiday@group.v.calendar.google.com",
+			"feed@import.calendar.google.com",
+		]) {
+			expect(isMachineAddress(email)).toBe(true);
+		}
+	});
+
+	it("catches sending infrastructure and reserved hosts", () => {
+		for (const email of [
+			"list@googlegroups.com",
+			"0100018f@bounce.acme.bounces.google.com",
+			"reply@em1234.amazonses.com",
+			"room@zoomcrc.com",
+			"someone@build.local",
+		]) {
+			expect(isMachineAddress(email)).toBe(true);
+		}
+	});
+
+	it("catches an address that is an opaque identifier", () => {
+		for (const email of [
+			"c_f5ecd6a22aea945a2d5c6ac9b8b2b16b@acme.com",
+			"4f9c2b1a8e7d6c5b4a3f2e1d0c9b8a77@acme.com",
+			"1f2e3d4c-5b6a-7988-9a0b-1c2d3e4f5a6b@acme.com",
+		]) {
+			expect(isMachineAddress(email)).toBe(true);
+		}
+	});
+
+	it("leaves real people and real companies alone", () => {
+		for (const email of [
+			"jane@acme.com",
+			"ada@google.com",
+			"dave@calendar.acme.com",
+			"deb@sendgrid.com",
+			"bob@testing.com",
+		]) {
+			expect(isMachineAddress(email)).toBe(false);
+		}
+	});
+});
+
 describe("workDomain", () => {
 	it("rejects the free hosts", () => {
 		expect(workDomain("someone@gmail.com")).toBeNull();
@@ -118,6 +166,21 @@ describe("externalParticipants", () => {
 				person("someone@gmail.com"),
 				person("recruiter@greenhouse.io"),
 				person("noreply@acme.com"),
+				person("jane@acme.com"),
+			],
+			options,
+		);
+
+		expect(result).toEqual([person("jane@acme.com")]);
+	});
+
+	it("never files a shared calendar as a person at a company", () => {
+		const result = externalParticipants(
+			[
+				person(
+					"c_f5ecd6a22aea945a2d5c6ac9b8b2b16b@group.calendar.google.com",
+					"Interviews scheduled",
+				),
 				person("jane@acme.com"),
 			],
 			options,

--- a/apps/api/test/google-participants.spec.ts
+++ b/apps/api/test/google-participants.spec.ts
@@ -96,6 +96,7 @@ describe("externalParticipants", () => {
 		ourDomains: new Set(["trycomp.ai"]),
 		ourAddresses: new Set(["lewis@trycomp.ai"]),
 		suppressedDomains: new Set(["greenhouse.io"]),
+		suppressedEmails: new Set(["deleted@acme.com"]),
 	};
 
 	it("keeps only the other side of the conversation", () => {
@@ -128,6 +129,24 @@ describe("externalParticipants", () => {
 	it("returns nothing for a wholly internal thread", () => {
 		expect(
 			externalParticipants([person("colleague@trycomp.ai")], options),
+		).toEqual([]);
+	});
+
+	it("never brings back a contact a rep deleted", () => {
+		const result = externalParticipants(
+			[person("deleted@acme.com", "Deleted Person"), person("jane@acme.com")],
+			options,
+		);
+
+		expect(result).toEqual([person("jane@acme.com")]);
+	});
+
+	it("leaves nothing to file when the deleted contact is the only outsider", () => {
+		expect(
+			externalParticipants(
+				[person("lewis@trycomp.ai"), person("deleted@acme.com")],
+				options,
+			),
 		).toEqual([]);
 	});
 });

--- a/apps/api/test/record-delete.spec.ts
+++ b/apps/api/test/record-delete.spec.ts
@@ -191,6 +191,41 @@ describe("deleting a contact", () => {
 		await db.contact.delete({ where: { id: readded.id } });
 		await db.suppressedContact.deleteMany({ where: { email } });
 	});
+
+	it("suppresses an address a rep typed in caps as the sync will see it", async () => {
+		const typed = `Mixed.Case@${domain.toUpperCase()}`;
+		const asSynced = typed.toLowerCase();
+
+		const created = await contacts.create({ firstName: "Mixed", email: typed });
+
+		expect(
+			await db.contact.findUnique({
+				where: { id: created.id },
+				select: { email: true },
+			}),
+		).toEqual({ email: asSynced });
+
+		await contacts.delete(created.id);
+
+		expect(
+			await db.suppressedContact.findUnique({ where: { email: asSynced } }),
+		).not.toBeNull();
+
+		const result = await match.resolve(
+			{
+				participants: [{ email: asSynced, name: "Mixed Case" }],
+				allowCreate: true,
+				source: RecordSource.EMAIL,
+				ownerId: userId,
+			},
+			await matchContext(),
+		);
+
+		expect(result.external).toEqual([]);
+		expect(
+			await db.contact.findFirst({ where: { email: asSynced } }),
+		).toBeNull();
+	});
 });
 
 describe("deleting a company", () => {

--- a/apps/api/test/record-delete.spec.ts
+++ b/apps/api/test/record-delete.spec.ts
@@ -13,6 +13,8 @@ import { GoogleMatchService } from "../src/google/google-match.service";
 const suffix = process.env.TEST_RUN_ID ?? "record-delete-spec";
 const domain = `delete-${suffix}.test`;
 const doomedDomain = `doomed-${suffix}.test`;
+const stampDomain = `stamped-${suffix}.test`;
+const orphanDomain = `orphaned-${suffix}.test`;
 const email = `gone@${domain}`;
 const colleague = `stays@${domain}`;
 const userId = `user-${suffix}`;
@@ -49,7 +51,7 @@ async function matchContext() {
 	};
 }
 
-const domains = [domain, doomedDomain];
+const domains = [domain, doomedDomain, stampDomain, orphanDomain];
 const ours = {
 	OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })),
 };
@@ -262,6 +264,96 @@ describe("deleting a company", () => {
 			select: { companyId: true },
 		});
 		expect(survivor?.companyId).toBeNull();
+
+		await db.contact.delete({ where: { id: contact.id } });
+	});
+});
+
+describe("the activity stamps a delete leaves behind", () => {
+	it("are recomputed on every record the deleted one's activities touched", async () => {
+		const company = await companies.create({
+			name: "Stamped",
+			domain: stampDomain,
+		});
+		const contact = await contacts.create({
+			firstName: "Stamped",
+			email: `stamped@${stampDomain}`,
+			companyId: company.id,
+		});
+		const deal = await db.deal.create({
+			data: { name: "Stamped deal", companyId: company.id, ownerId: userId },
+			select: { id: true },
+		});
+
+		const at = new Date();
+		await db.activity.create({
+			data: {
+				type: "NOTE",
+				subject: "The only thing on this account",
+				companyId: company.id,
+				contactId: contact.id,
+				dealId: deal.id,
+				createdById: userId,
+				createdAt: at,
+			},
+		});
+		await stamp.touch(
+			{ companyId: company.id, contactId: contact.id, dealId: deal.id },
+			at,
+		);
+
+		await contacts.delete(contact.id);
+
+		expect(
+			await db.company.findUnique({
+				where: { id: company.id },
+				select: { lastActivityAt: true },
+			}),
+		).toEqual({ lastActivityAt: null });
+		expect(
+			await db.deal.findUnique({
+				where: { id: deal.id },
+				select: { lastActivityAt: true },
+			}),
+		).toEqual({ lastActivityAt: null });
+	});
+
+	it("follow a deleted company through the deals it takes with it", async () => {
+		const company = await companies.create({
+			name: "Orphaner",
+			domain: orphanDomain,
+		});
+		const contact = await contacts.create({
+			firstName: "Orphaned",
+			email: `orphaned@${orphanDomain}`,
+			companyId: company.id,
+		});
+		const deal = await db.deal.create({
+			data: { name: "Orphaned deal", companyId: company.id, ownerId: userId },
+			select: { id: true },
+		});
+
+		const at = new Date();
+		await db.activity.create({
+			data: {
+				type: "MEETING",
+				subject: "Only ever attached to the deal",
+				contactId: contact.id,
+				dealId: deal.id,
+				createdById: userId,
+				createdAt: at,
+			},
+		});
+		await stamp.touch({ contactId: contact.id, dealId: deal.id }, at);
+
+		await companies.delete(company.id);
+
+		expect(
+			await db.contact.findUnique({
+				where: { id: contact.id },
+				select: { companyId: true, lastActivityAt: true },
+			}),
+		).toEqual({ companyId: null, lastActivityAt: null });
 
 		await db.contact.delete({ where: { id: contact.id } });
 	});

--- a/apps/api/test/record-delete.spec.ts
+++ b/apps/api/test/record-delete.spec.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { db, RecordSource } from "@crm/db";
+import { AgentQueueService } from "../src/agent/agent-queue.service";
+import { AgentTriggerService } from "../src/agent/agent-trigger.service";
+import { CompaniesService } from "../src/companies/companies.service";
+import { CompanyDirectoryService } from "../src/companies/company-directory.service";
+import { FaviconService } from "../src/companies/favicon.service";
+import { ContactsService } from "../src/contacts/contacts.service";
+import { ActivityStampService } from "../src/crm/activity-stamp.service";
+import { EnrichmentLogService } from "../src/crm/enrichment-log.service";
+import { GoogleMatchService } from "../src/google/google-match.service";
+
+const suffix = process.env.TEST_RUN_ID ?? "record-delete-spec";
+const domain = `delete-${suffix}.test`;
+const doomedDomain = `doomed-${suffix}.test`;
+const email = `gone@${domain}`;
+const colleague = `stays@${domain}`;
+const userId = `user-${suffix}`;
+
+const stamp = new ActivityStampService(db);
+const agent = new AgentTriggerService(db);
+const directory = new CompanyDirectoryService(db, agent);
+const log = new EnrichmentLogService(db, stamp);
+const queue = new AgentQueueService(db);
+
+const contacts = new ContactsService(db, directory, agent, queue, stamp);
+const companies = new CompaniesService(
+	db,
+	agent,
+	queue,
+	{ backfill: async () => undefined } as unknown as FaviconService,
+	stamp,
+);
+const match = new GoogleMatchService(db, directory, agent, log);
+
+async function matchContext() {
+	const internal = await match.internalIdentity();
+	return {
+		ourAddresses: internal.addresses,
+		ourDomains: internal.domains,
+		suppressedDomains: await match.suppressedDomains(),
+		suppressedEmails: await match.suppressedEmails(),
+	};
+}
+
+async function clean() {
+	const domains = [domain, doomedDomain];
+	await db.contact.deleteMany({
+		where: { OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })) },
+	});
+	await db.company.deleteMany({ where: { domain: { in: domains } } });
+	await db.suppressedContact.deleteMany({
+		where: { OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })) },
+	});
+	await db.user.deleteMany({ where: { id: userId } });
+}
+
+beforeAll(async () => {
+	await clean();
+	await db.user.create({
+		data: { id: userId, name: "Test Rep", email: `${userId}@example.test` },
+	});
+});
+
+afterAll(clean);
+
+describe("deleting a contact", () => {
+	let contactId: string;
+
+	it("takes the record, its queued research and its transcript with it", async () => {
+		const created = await contacts.create({
+			firstName: "Gone",
+			lastName: "Person",
+			email,
+			ownerId: userId,
+		});
+		contactId = created.id;
+
+		await db.agentEvent.create({
+			data: {
+				id: `evt-${suffix}`,
+				sessionId: `ses-${suffix}`,
+				contactId,
+				type: "session.started",
+				data: {},
+				emittedAt: new Date(),
+			},
+		});
+
+		expect(await contacts.delete(contactId)).toEqual({
+			id: contactId,
+			name: "Gone Person",
+		});
+
+		expect(
+			await db.contact.findUnique({ where: { id: contactId } }),
+		).toBeNull();
+		expect(await db.agentTask.count({ where: { contactId } })).toBe(0);
+		expect(await db.agentEvent.count({ where: { contactId } })).toBe(0);
+	});
+
+	it("remembers the address so the sync cannot bring them back", async () => {
+		const suppressed = await db.suppressedContact.findUnique({
+			where: { email },
+		});
+		expect(suppressed).not.toBeNull();
+
+		const result = await match.resolve(
+			{
+				participants: [{ email, name: "Gone Person" }],
+				allowCreate: true,
+				source: RecordSource.EMAIL,
+				ownerId: userId,
+			},
+			await matchContext(),
+		);
+
+		expect(result.external).toEqual([]);
+		expect(result.contactId).toBeNull();
+		expect(await db.contact.findFirst({ where: { email } })).toBeNull();
+	});
+
+	it("still files the colleagues who were not deleted", async () => {
+		const result = await match.resolve(
+			{
+				participants: [
+					{ email, name: "Gone Person" },
+					{ email: colleague, name: "Stays Here" },
+				],
+				allowCreate: true,
+				source: RecordSource.EMAIL,
+				ownerId: userId,
+			},
+			await matchContext(),
+		);
+
+		expect(result.external.map((person) => person.email)).toEqual([colleague]);
+
+		const created = await db.contact.findFirst({ where: { email: colleague } });
+		expect(created?.id).toBe(result.contactId ?? undefined);
+	});
+
+	it("lets a rep add them back by hand, which lifts the suppression", async () => {
+		const readded = await contacts.create({ firstName: "Gone", email });
+
+		expect(
+			await db.suppressedContact.findUnique({ where: { email } }),
+		).toBeNull();
+
+		await db.contact.delete({ where: { id: readded.id } });
+		await db.suppressedContact.deleteMany({ where: { email } });
+	});
+});
+
+describe("deleting a company", () => {
+	it("takes its deals and leaves its people without a company", async () => {
+		const company = await companies.create({
+			name: "Doomed",
+			domain: doomedDomain,
+		});
+		const contact = await contacts.create({
+			firstName: "Left",
+			lastName: "Behind",
+			email: `left@${doomedDomain}`,
+			companyId: company.id,
+		});
+		const deal = await db.deal.create({
+			data: { name: "Doomed deal", companyId: company.id, ownerId: userId },
+			select: { id: true },
+		});
+
+		expect(await companies.delete(company.id)).toEqual({
+			id: company.id,
+			name: "Doomed",
+		});
+
+		expect(await db.deal.findUnique({ where: { id: deal.id } })).toBeNull();
+		expect(await db.agentTask.count({ where: { companyId: company.id } })).toBe(
+			0,
+		);
+
+		const survivor = await db.contact.findUnique({
+			where: { id: contact.id },
+			select: { companyId: true },
+		});
+		expect(survivor?.companyId).toBeNull();
+
+		await db.contact.delete({ where: { id: contact.id } });
+	});
+});

--- a/apps/api/test/record-delete.spec.ts
+++ b/apps/api/test/record-delete.spec.ts
@@ -18,7 +18,13 @@ const colleague = `stays@${domain}`;
 const userId = `user-${suffix}`;
 
 const stamp = new ActivityStampService(db);
-const agent = new AgentTriggerService(db);
+
+const agent = {
+	contactCreated: async () => undefined,
+	companyCreated: async () => undefined,
+	companyRequested: async () => undefined,
+} as unknown as AgentTriggerService;
+
 const directory = new CompanyDirectoryService(db, agent);
 const log = new EnrichmentLogService(db, stamp);
 const queue = new AgentQueueService(db);
@@ -43,15 +49,48 @@ async function matchContext() {
 	};
 }
 
+const domains = [domain, doomedDomain];
+const ours = {
+	OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })),
+};
+
+async function parked(subject: { contactId?: string; companyId?: string }) {
+	return db.agentTask.create({
+		data: {
+			...subject,
+			kind: "identify",
+			reason: `record-delete-spec (${suffix})`,
+			dueAt: new Date(Date.now() + 60 * 60 * 1000),
+		},
+		select: { id: true },
+	});
+}
+
 async function clean() {
-	const domains = [domain, doomedDomain];
-	await db.contact.deleteMany({
-		where: { OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })) },
+	const [existingContacts, existingCompanies] = await Promise.all([
+		db.contact.findMany({ where: ours, select: { id: true } }),
+		db.company.findMany({
+			where: { domain: { in: domains } },
+			select: { id: true },
+		}),
+	]);
+
+	const contactIds = existingContacts.map((row) => row.id);
+	const companyIds = existingCompanies.map((row) => row.id);
+
+	await db.agentTask.deleteMany({
+		where: {
+			OR: [
+				{ reason: `record-delete-spec (${suffix})` },
+				{ contactId: { in: contactIds } },
+				{ companyId: { in: companyIds } },
+			],
+		},
 	});
+	await db.agentEvent.deleteMany({ where: { contactId: { in: contactIds } } });
+	await db.contact.deleteMany({ where: ours });
 	await db.company.deleteMany({ where: { domain: { in: domains } } });
-	await db.suppressedContact.deleteMany({
-		where: { OR: domains.map((host) => ({ email: { endsWith: `@${host}` } })) },
-	});
+	await db.suppressedContact.deleteMany({ where: ours });
 	await db.user.deleteMany({ where: { id: userId } });
 }
 
@@ -75,6 +114,8 @@ describe("deleting a contact", () => {
 			ownerId: userId,
 		});
 		contactId = created.id;
+
+		await parked({ contactId });
 
 		await db.agentEvent.create({
 			data: {
@@ -168,6 +209,8 @@ describe("deleting a company", () => {
 			data: { name: "Doomed deal", companyId: company.id, ownerId: userId },
 			select: { id: true },
 		});
+
+		await parked({ companyId: company.id });
 
 		expect(await companies.delete(company.id)).toEqual({
 			id: company.id,

--- a/apps/api/test/workspace.spec.ts
+++ b/apps/api/test/workspace.spec.ts
@@ -67,6 +67,7 @@ describe("internal addresses never become leads", () => {
 		ourDomains: new Set(["acme.com"]),
 		ourAddresses: new Set<string>(),
 		suppressedDomains: new Set<string>(),
+		suppressedEmails: new Set<string>(),
 	};
 
 	it("drops colleagues even when they are not users", () => {

--- a/apps/app/components/crm/record-sheet/company-sheet.tsx
+++ b/apps/app/components/crm/record-sheet/company-sheet.tsx
@@ -58,6 +58,7 @@ import { useCrmCache } from "@/lib/trpc/cache";
 import { useTRPC } from "@/lib/trpc/client";
 import type { RouterOutputs } from "@/lib/trpc/types";
 import { QuickAddContact, QuickAddDeal } from "./quick-add";
+import { RecordActions } from "./record-actions";
 import {
 	DealAmount,
 	DomainLink,
@@ -77,6 +78,23 @@ function pendingFields(company: Company): string[] {
 	if (!company.description) missing.push("description");
 	if (!hasCompanyLinks(company)) missing.push("social links");
 	return missing;
+}
+
+function companyConsequence(company: Company): string {
+	const deals = company.deals.length;
+	const contacts = company.contacts.length;
+
+	const gone =
+		deals > 0
+			? `${deals === 1 ? "Its one deal" : `All ${deals} of its deals`} and everything filed against the account go too.`
+			: "Everything filed against the account goes too.";
+
+	const kept =
+		contacts > 0
+			? ` ${contacts === 1 ? "The one person" : `The ${contacts} people`} who work there stay in the CRM, without a company.`
+			: "";
+
+	return gone + kept;
 }
 
 const CONTACT_COLUMNS = [
@@ -265,10 +283,17 @@ export function CompanySheet({ companyId }: { companyId: string }) {
 			}
 			actions={
 				company ? (
-					<EnrichmentActions
-						companyId={company.id}
-						hasDomain={company.domain !== null}
-					/>
+					<>
+						<EnrichmentActions
+							companyId={company.id}
+							hasDomain={company.domain !== null}
+						/>
+						<RecordActions
+							record={{ kind: "company", id: company.id }}
+							name={company.name}
+							consequence={companyConsequence(company)}
+						/>
+					</>
 				) : null
 			}
 			stats={

--- a/apps/app/components/crm/record-sheet/contact-sheet.tsx
+++ b/apps/app/components/crm/record-sheet/contact-sheet.tsx
@@ -58,6 +58,7 @@ import {
 import { useCrmCache } from "@/lib/trpc/cache";
 import { useTRPC } from "@/lib/trpc/client";
 import type { RouterOutputs } from "@/lib/trpc/types";
+import { RecordActions } from "./record-actions";
 import { DealAmount, MetaLine, RecordSheetFrame } from "./record-parts";
 import { useOpenRecord, useRecordSheetView } from "./record-stack";
 
@@ -197,6 +198,11 @@ export function ContactSheet({ contactId }: { contactId: string }) {
 								<span className="hidden sm:inline">Make primary</span>
 							</Button>
 						) : null}
+						<RecordActions
+							record={{ kind: "contact", id: contact.id }}
+							name={contactName(contact)}
+							consequence={`Their notes, agent conversations and everything the agent found go too; emails and meetings stay filed against the company.${contact.email ? ` The sync will not bring ${contact.email} back — only adding them yourself will.` : ""}`}
+						/>
 					</>
 				) : null
 			}

--- a/apps/app/components/crm/record-sheet/deal-sheet.tsx
+++ b/apps/app/components/crm/record-sheet/deal-sheet.tsx
@@ -40,6 +40,7 @@ import {
 import { useCrmCache } from "@/lib/trpc/cache";
 import { useTRPC } from "@/lib/trpc/client";
 import type { RouterOutputs } from "@/lib/trpc/types";
+import { RecordActions } from "./record-actions";
 import { RecordSheetFrame } from "./record-parts";
 import { useOpenRecord, useRecordSheetView } from "./record-stack";
 
@@ -122,11 +123,18 @@ export function DealSheet({ dealId }: { dealId: string }) {
 			}
 			actions={
 				deal ? (
-					<DealStageMenu
-						dealId={deal.id}
-						stage={deal.stage}
-						variant="control"
-					/>
+					<>
+						<DealStageMenu
+							dealId={deal.id}
+							stage={deal.stage}
+							variant="control"
+						/>
+						<RecordActions
+							record={{ kind: "deal", id: deal.id }}
+							name={deal.name}
+							consequence={`Its stage history, notes and agent conversations go too. ${deal.company.name} and the ${deal.contacts.length === 1 ? "person" : "people"} on it stay in the CRM.`}
+						/>
+					</>
 				) : null
 			}
 			stats={

--- a/apps/app/components/crm/record-sheet/record-actions.tsx
+++ b/apps/app/components/crm/record-sheet/record-actions.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import OverflowMenuVertical from "@carbon/icons-react/es/OverflowMenuVertical";
+import TrashCan from "@carbon/icons-react/es/TrashCan";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@crm/ui/components/alert-dialog";
+import { Button } from "@crm/ui/components/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@crm/ui/components/dropdown-menu";
+import { Icon } from "@crm/ui/components/icon";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useCrmCache } from "@/lib/trpc/cache";
+import { useTRPC } from "@/lib/trpc/client";
+import {
+	type RecordKind,
+	type RecordRef,
+	useRecordStack,
+} from "./record-stack";
+
+const NOUN: Record<RecordKind, string> = {
+	company: "company",
+	contact: "contact",
+	deal: "deal",
+};
+
+function useDeleteRecord(record: RecordRef) {
+	const trpc = useTRPC();
+	const cache = useCrmCache();
+	const { close } = useRecordStack();
+
+	const handlers = {
+		onSuccess: (deleted: { name: string }) => {
+			toast.success(
+				`${deleted.name || `The ${NOUN[record.kind]}`} was deleted.`,
+			);
+			void cache.removed(record);
+			close();
+		},
+		onError: (error: { message: string }) => toast.error(error.message),
+	};
+
+	const options =
+		record.kind === "contact"
+			? trpc.contacts.delete.mutationOptions(handlers)
+			: record.kind === "company"
+				? trpc.companies.delete.mutationOptions(handlers)
+				: trpc.deals.delete.mutationOptions(handlers);
+
+	return useMutation(options);
+}
+
+export function RecordActions({
+	record,
+	name,
+	consequence,
+}: {
+	record: RecordRef;
+	name: string;
+	consequence: string;
+}) {
+	const [confirming, setConfirming] = useState(false);
+	const remove = useDeleteRecord(record);
+
+	return (
+		<>
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="ghost" size="icon-sm" disabled={remove.isPending}>
+						<Icon icon={OverflowMenuVertical} />
+						<span className="sr-only">More actions</span>
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end" className="min-w-44">
+					<DropdownMenuItem
+						variant="destructive"
+						onSelect={() => setConfirming(true)}
+					>
+						<Icon icon={TrashCan} />
+						Delete {NOUN[record.kind]}
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+
+			<AlertDialog open={confirming} onOpenChange={setConfirming}>
+				<AlertDialogContent>
+					<AlertDialogHeader>
+						<AlertDialogTitle>Delete {name}?</AlertDialogTitle>
+						<AlertDialogDescription>{consequence}</AlertDialogDescription>
+					</AlertDialogHeader>
+
+					<AlertDialogFooter>
+						<AlertDialogCancel>Cancel</AlertDialogCancel>
+						<AlertDialogAction
+							variant="destructive"
+							onClick={() => remove.mutate({ id: record.id })}
+						>
+							Delete
+						</AlertDialogAction>
+					</AlertDialogFooter>
+				</AlertDialogContent>
+			</AlertDialog>
+		</>
+	);
+}

--- a/apps/app/lib/trpc/cache.ts
+++ b/apps/app/lib/trpc/cache.ts
@@ -103,13 +103,12 @@ export function useCrmCache(): CrmCache {
 			),
 
 		removed: ({ kind, id }) => {
-			const gone = JSON.stringify(
-				{
-					company: trpc.companies.byId,
-					contact: trpc.contacts.byId,
-					deal: trpc.deals.byId,
-				}[kind].queryKey({ id }),
-			);
+			const goneKey = {
+				company: trpc.companies.byId,
+				contact: trpc.contacts.byId,
+				deal: trpc.deals.byId,
+			}[kind].queryKey({ id });
+			const gone = JSON.stringify(goneKey);
 
 			for (const record of [
 				trpc.companies.byId,
@@ -121,6 +120,12 @@ export function useCrmCache(): CrmCache {
 					predicate: (query) => JSON.stringify(query.queryKey) !== gone,
 				});
 			}
+
+			void queryClient.invalidateQueries({
+				queryKey: goneKey,
+				exact: true,
+				refetchType: "none",
+			});
 
 			return run(
 				[...listKeys(), ...activityKeys(), trpc.dashboard.summary.queryKey()],

--- a/apps/app/lib/trpc/cache.ts
+++ b/apps/app/lib/trpc/cache.ts
@@ -9,10 +9,13 @@ type Options = {
 	settle?: Settle;
 };
 
+type RemovedRecord = { kind: "company" | "contact" | "deal"; id: string };
+
 export type CrmCache = {
 	company(id?: string, options?: Options): Promise<void>;
 	contact(id?: string, options?: Options): Promise<void>;
 	deal(id?: string, options?: Options): Promise<void>;
+	removed(record: RemovedRecord): Promise<void>;
 	activity(options?: Options): Promise<void>;
 	google(options?: Options): Promise<void>;
 	settings(options?: Options): Promise<void>;
@@ -98,6 +101,32 @@ export function useCrmCache(): CrmCache {
 				],
 				options,
 			),
+
+		removed: ({ kind, id }) => {
+			const gone = JSON.stringify(
+				{
+					company: trpc.companies.byId,
+					contact: trpc.contacts.byId,
+					deal: trpc.deals.byId,
+				}[kind].queryKey({ id }),
+			);
+
+			for (const record of [
+				trpc.companies.byId,
+				trpc.contacts.byId,
+				trpc.deals.byId,
+			]) {
+				void queryClient.invalidateQueries({
+					queryKey: record.queryKey(),
+					predicate: (query) => JSON.stringify(query.queryKey) !== gone,
+				});
+			}
+
+			return run(
+				[...listKeys(), ...activityKeys(), trpc.dashboard.summary.queryKey()],
+				[],
+			);
+		},
 
 		activity: (options) =>
 			run(

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -1,3 +1,4 @@
+import { AUTH_COOKIE_PREFIX } from "@crm/auth/cookies";
 import { getSessionCookie } from "better-auth/cookies";
 import { type NextRequest, NextResponse } from "next/server";
 import {
@@ -14,7 +15,9 @@ const UNGATED = [SIGN_IN_PATH, "/grant-access", "/eve"];
 export async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
-	if (getSessionCookie(request) === null) {
+	if (
+		getSessionCookie(request, { cookiePrefix: AUTH_COOKIE_PREFIX }) === null
+	) {
 		return pathname === SIGN_IN_PATH
 			? NextResponse.next()
 			: NextResponse.redirect(new URL(SIGN_IN_PATH, request.nextUrl));

--- a/apps/app/test/onboarding-gate.spec.ts
+++ b/apps/app/test/onboarding-gate.spec.ts
@@ -86,6 +86,7 @@ describe("proxy", () => {
 	});
 
 	it("ignores a neighbour's cookie from the parent domain", async () => {
+		expect(AUTH_COOKIE_PREFIX).not.toBe("better-auth");
 		answerWith(workspace({ onboarded: true, canRename: true }));
 
 		expect(

--- a/apps/app/test/onboarding-gate.spec.ts
+++ b/apps/app/test/onboarding-gate.spec.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { AUTH_COOKIE_PREFIX } from "@crm/auth/cookies";
 import { NextRequest } from "next/server";
 import { ONBOARDING_COOKIE, readOnboardingGate } from "../lib/onboarding";
 import { proxy } from "../proxy";
 
-const SESSION_COOKIE = "better-auth.session_token=abc.def";
+const SESSION_COOKIE = `${AUTH_COOKIE_PREFIX}.session_token=abc.def`;
 
 const realFetch = globalThis.fetch;
 
@@ -82,6 +83,18 @@ describe("proxy", () => {
 	it("sends a stranger to sign in, and leaves them there", async () => {
 		expect(redirectedTo(await proxy(request("/companies")))).toBe("/sign-in");
 		expect(redirectedTo(await proxy(request("/sign-in")))).toBeNull();
+	});
+
+	it("ignores a neighbour's cookie from the parent domain", async () => {
+		answerWith(workspace({ onboarded: true, canRename: true }));
+
+		expect(
+			redirectedTo(
+				await proxy(
+					request("/companies", ["better-auth.session_token=someone.else"]),
+				),
+			),
+		).toBe("/sign-in");
 	});
 
 	it("gates a signed-in rep who has not answered the form", async () => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,6 +285,52 @@ Everything the app reads or writes goes through `nestjs-trpc` routers under
   run the generator. Regenerate locally and commit the result with the router
   change that caused it.
 
+## Not every address on a thread is a person
+
+`externalParticipants` (`apps/api/src/google/participants.ts`) is the one gate
+between what Google returns and what becomes a record, and it has to throw away
+three different kinds of thing before it gets to a lead: **us** (the allow-list
+domains and the `User` table), **a decision a rep made** (`SuppressedContact`,
+`SuppressedDomain`), and **an address no human has ever read**.
+
+The third is `isMachineAddress`, and it exists because of a company called
+`group.calendar.google.com` with one contact on it named "Interviews
+scheduled". A secondary Google calendar is invited to an event as an ordinary
+attendee — it is not flagged `resource`, the way a meeting room is — so it
+arrived with a display name and a plausible-looking domain and the sync did
+exactly what it does for a stranger at a customer: made a person, made a
+company, and queued research on both.
+
+- **A machine domain never becomes a company.** `isMachineDomain` in
+  `apps/api/src/companies/domain.ts` sits beside `FREE_EMAIL_DOMAINS` because
+  the two answer the same question — *is this host a company* — and
+  `domainFromEmail` returns `null` for both. That is the load-bearing half:
+  `companyForEmail` is the only way a company is derived from an address, so a
+  caller that never heard of this rule still cannot create one.
+  `.calendar.google.com` covers the shared calendars, the rooms, the imported
+  ICS feeds and the holiday calendars in one entry.
+- **It matches the *host*, never a substring.** `calendar.acme.com` and
+  `sendgrid.com` are somebody's real company; only the exact hosts and the
+  listed suffixes are refused.
+- **An opaque local part is the second door.** `c_f5ec…@` and a bare UUID are
+  identifiers, not names, and they come from providers whose infrastructure
+  hostname we have not learned yet. The patterns are deliberately narrow — 24
+  hex characters or a formatted UUID — because the cost of a false positive
+  here is a real customer who is silently never filed.
+- **It is not a suppression, and it leaves no row.** A rep can still type any of
+  these into the quick-add form; the rule is only that the *inbox* may not
+  decide they are worth a record. `SuppressedContact` is for a person a rep
+  deleted, and writing one for a calendar id would be recording a decision
+  nobody made.
+- **The attendee list is filtered too.** `syncAttendees` drops the same
+  addresses beside `attendee.resource`, so a shared calendar is not listed as
+  somebody who came to the meeting.
+
+Shared inboxes and the machines that send invitations are a separate list,
+`isAutomatedAddress` — `sales@`, `noreply@`, `bookings@`. That one is about the
+*local part*, and it is the reason `support@acme.com` never becomes a lead at a
+company we do genuinely sell to.
+
 ## Deleting a record is a decision the sync has to respect
 
 Each of the three records can be deleted from the three-dot menu in its sheet —

--- a/docs/api.md
+++ b/docs/api.md
@@ -362,6 +362,16 @@ once.
   suppression written by `contacts.delete`. The conflict check on create and
   `allowAgain` both match case-insensitively so a row written before this rule
   still answers.
+- **The address is taken from the delete itself, not from a read before it.**
+  `contacts.delete` runs `tx.contact.delete({ select: { email: true } })` inside
+  the transaction and suppresses what comes back, so the row it writes down is
+  the address the contact had at the moment it ceased to exist. A pre-check read
+  is a different question asked earlier: a rep correcting the address in one tab
+  while another deletes the record left the old address suppressed and the new
+  one open, which is the same recreated-contact loop wearing a different hat.
+  It is also what supplies the name in the `reason`, and the 404 — a missing
+  contact is now the delete's own `P2025` through `translate`, rather than a
+  pre-check that a concurrent delete could pass.
 - **The colleagues are untouched.** Only the deleted address is filtered, so a
   thread with three other people at that company still files against them. A
   thread where the deleted person was the *only* outsider files against nobody,
@@ -385,13 +395,33 @@ survives a redeploy — which means a delete has to clear them itself. Leaving
 them behind queues research about a person who no longer exists, and the
 dispatcher spends a session finding that out.
 
-Every delete then calls `ActivityStampService.recomputeAllAfterDelete()`.
-Deleting a record deletes its activities, and `lastActivityAt` on whatever else
-those activities touched is a cached maximum that nothing else recomputes — a
-company whose only recent activity was on a deleted deal would sort as though
-the work were still fresh, forever.
+**The stamps are then recomputed on the records the delete actually reached,
+and no others.** Deleting a record deletes its activities, and `lastActivityAt`
+on whatever else those activities touched is a cached maximum that nothing else
+recomputes — a company whose only recent activity was on a deleted deal would
+sort as though the work were still fresh, forever.
 
-**It runs after the delete has committed, so it logs rather than throws.** The
+- **The affected set is read before the rows go, inside the delete's own
+  transaction.** `ActivityStampService.targetsOf(where)` groups the activities a
+  delete is about to destroy by each of their three foreign keys and hands back
+  the ids; `recomputeMany` restamps exactly those rows, one `UPDATE … SET
+  lastActivityAt = (SELECT MAX(…))` per table, which covers "has newer
+  activities" and "has none left, so null" in the same statement. Reading it
+  after the delete is not an option — the evidence is what was deleted.
+- **A company's `where` follows the deals it takes with it**, `{ OR: [{
+  companyId }, { deal: { companyId } }] }`. Deleting a company cascades to its
+  deals and those cascade to their activities, so a surviving contact whose only
+  activity hung off one of those deals would keep a stamp for work that no
+  longer exists. `test/record-delete.spec.ts` pins that branch specifically.
+- **`recomputeAll()` is still there and is still right for a purge.** It rebuilds
+  every stamp in the CRM with six full-table statements, which is what
+  disconnecting Google and dropping everything it synced needs. It is the wrong
+  tool for deleting one record: it made the cost of removing a contact a
+  function of the size of the entire CRM, and it repaired rows the rep's action
+  never touched.
+
+**Recomputing runs after the delete has committed, so it logs rather than
+throws.** The
 row is already gone by the time the stamps are rebuilt; letting that failure out
 reports a completed destructive action as a failure, the browser never
 invalidates its caches, and the rep's retry answers `No contact with id …`. A

--- a/docs/api.md
+++ b/docs/api.md
@@ -285,6 +285,53 @@ Everything the app reads or writes goes through `nestjs-trpc` routers under
   run the generator. Regenerate locally and commit the result with the router
   change that caused it.
 
+## Deleting a record is a decision the sync has to respect
+
+Each of the three records can be deleted from the three-dot menu in its sheet —
+`contacts.delete`, `companies.delete`, `deals.delete`, one confirm dialog each.
+There is no soft delete and no archive: a row a rep meant to be gone that is
+still in every list, facet and count is worse than either.
+
+**A deleted contact is remembered by address.** Deleting the row is not enough,
+because the Gmail and Calendar sync creates contacts from whoever is on a thread
+— so the next message from that person put them straight back, with a fresh
+`identify` task behind them, and the rep's only recourse was to delete them
+again every few days. `ContactsService.delete` writes a `SuppressedContact` row
+keyed on the email, and `externalParticipants`
+(`apps/api/src/google/participants.ts`) drops that address exactly as it drops a
+domain in `SuppressedDomain` — one filter, one place, so the address is
+invisible to contact creation, company auto-creation and thread attribution at
+once.
+
+- **It suppresses the address, not the person.** A contact with no email cannot
+  be recreated by the sync in the first place — the sync only knows people by
+  address — so there is nothing to write down.
+- **The colleagues are untouched.** Only the deleted address is filtered, so a
+  thread with three other people at that company still files against them. A
+  thread where the deleted person was the *only* outsider files against nobody,
+  which is the correct reading of "we do not track this person".
+- **A rep can always add them back, and doing so lifts the suppression.**
+  `allowAgain` runs on `contacts.create` and on an `update` that sets the email.
+  The rule is *not added back automatically* — somebody typing the address in is
+  not the inbox making the decision for them.
+- **Deleting a company does not suppress its domain.** Its people survive the
+  delete with no company, and a domain-wide suppression would silently stop
+  filing their email too. Turning off a whole domain stays the explicit control
+  on Settings → Connections, where it says what it does.
+
+**What the database does not cascade, the service does.** `AgentTask` and
+`AgentEvent` carry a `contactId` and a `companyId` as plain columns with no
+foreign key — they outlive the records they name on purpose, so the queue
+survives a redeploy — which means a delete has to clear them itself. Leaving
+them behind queues research about a person who no longer exists, and the
+dispatcher spends a session finding that out.
+
+Every delete then calls `ActivityStampService.recomputeAll()`. Deleting a record
+deletes its activities, and `lastActivityAt` on whatever else those activities
+touched is a cached maximum that nothing else recomputes — a company whose only
+recent activity was on a deleted deal would sort as though the work were still
+fresh, forever.
+
 ## Freshness: invalidate the query, don't disable the cache
 
 There is no HTTP response cache in front of tRPC. Freshness is TanStack Query's
@@ -298,6 +345,17 @@ job: a mutation invalidates the query keys it affected, and the list refetches.
   timeline entry it writes, creating a deal did not refresh the board, and nothing
   refreshed the overview, so a rep could close a deal and watch their own numbers
   not move. **A new mutation adds a call there, not a new list of keys.**
+- **A deletion is `cache.removed(ref)`, and it is the one call that skips a
+  key.** Everything a deletion can reach is refreshed together — the lists, the
+  timeline, the dashboard, and the other records that named this one, since a
+  colleague list and a deal's attendees both go stale the moment a contact goes.
+  The deleted record's *own* `byId` entry is deliberately left alone: its query is
+  still mounted for the moment it takes the sheet to animate shut, so
+  invalidating it asks the API for a row that no longer exists and the sheet
+  reads the 404 as "this record could not be loaded" on its way out. Nothing
+  observes that entry once the sheet is gone, so it expires on its own. One wide
+  fan-out is right here because deleting is rare and touches more than any edit
+  does.
 - **Pass `{ settle: "record" }`** when the caller is an inline editor. The
   default waits for every affected view to refetch, which is right when the point
   of the action *is* the view changing (a card moving between board columns);

--- a/docs/api.md
+++ b/docs/api.md
@@ -352,12 +352,25 @@ once.
 - **It suppresses the address, not the person.** A contact with no email cannot
   be recreated by the sync in the first place — the sync only knows people by
   address — so there is nothing to write down.
+- **The key is the address as the sync will see it: lower case.**
+  `parseAddress` lower-cases everything Google hands us, so a rep who typed
+  `Paula.Marchetti@Fernhill.com` into the quick-add form and then deleted the
+  contact left a suppression nothing would ever match, and the next thread put
+  them straight back — the exact loop the row exists to break. `normalizeEmail`
+  (`apps/api/src/crm/values.ts`) is the one canonicaliser, applied where a rep's
+  typing enters the system: `contacts.create`, `contacts.update` and the
+  suppression written by `contacts.delete`. The conflict check on create and
+  `allowAgain` both match case-insensitively so a row written before this rule
+  still answers.
 - **The colleagues are untouched.** Only the deleted address is filtered, so a
   thread with three other people at that company still files against them. A
   thread where the deleted person was the *only* outsider files against nobody,
   which is the correct reading of "we do not track this person".
 - **A rep can always add them back, and doing so lifts the suppression.**
-  `allowAgain` runs on `contacts.create` and on an `update` that sets the email.
+  `allowAgain` runs on `contacts.create` and on an `update` that sets the email,
+  **inside the same transaction as the write**. Outside it, a database blip
+  between the two left a contact the sync still ignores, and the retry hit the
+  "already uses that email" conflict — a record a rep can see and cannot fix.
   The rule is *not added back automatically* — somebody typing the address in is
   not the inbox making the decision for them.
 - **Deleting a company does not suppress its domain.** Its people survive the
@@ -372,11 +385,20 @@ survives a redeploy — which means a delete has to clear them itself. Leaving
 them behind queues research about a person who no longer exists, and the
 dispatcher spends a session finding that out.
 
-Every delete then calls `ActivityStampService.recomputeAll()`. Deleting a record
-deletes its activities, and `lastActivityAt` on whatever else those activities
-touched is a cached maximum that nothing else recomputes — a company whose only
-recent activity was on a deleted deal would sort as though the work were still
-fresh, forever.
+Every delete then calls `ActivityStampService.recomputeAllAfterDelete()`.
+Deleting a record deletes its activities, and `lastActivityAt` on whatever else
+those activities touched is a cached maximum that nothing else recomputes — a
+company whose only recent activity was on a deleted deal would sort as though
+the work were still fresh, forever.
+
+**It runs after the delete has committed, so it logs rather than throws.** The
+row is already gone by the time the stamps are rebuilt; letting that failure out
+reports a completed destructive action as a failure, the browser never
+invalidates its caches, and the rep's retry answers `No contact with id …`. A
+stale sort order is a smaller wrong than that, and the next delete or
+reconnection recomputes it. The delete itself is still translated: a record
+removed between the pre-check and the delete is the documented 404, not a P2025
+escaping as a 500.
 
 ## Freshness: invalidate the query, don't disable the cache
 
@@ -395,13 +417,16 @@ job: a mutation invalidates the query keys it affected, and the list refetches.
   key.** Everything a deletion can reach is refreshed together — the lists, the
   timeline, the dashboard, and the other records that named this one, since a
   colleague list and a deal's attendees both go stale the moment a contact goes.
-  The deleted record's *own* `byId` entry is deliberately left alone: its query is
-  still mounted for the moment it takes the sheet to animate shut, so
-  invalidating it asks the API for a row that no longer exists and the sheet
-  reads the 404 as "this record could not be loaded" on its way out. Nothing
-  observes that entry once the sheet is gone, so it expires on its own. One wide
-  fan-out is right here because deleting is rare and touches more than any edit
-  does.
+  The deleted record's *own* `byId` entry is invalidated with
+  `refetchType: "none"`, which is the one place that option is right: its query
+  is still mounted for the moment it takes the sheet to animate shut, so a
+  refetch asks the API for a row that no longer exists and the sheet reads the
+  404 as "this record could not be loaded" on its way out. Marking it stale
+  without refetching keeps the closing sheet quiet *and* stops the entry being
+  served from cache — `staleTime` is 30 seconds, so leaving it untouched meant a
+  rep who reopened the record from a stale link or the back button read half a
+  minute of a record that no longer exists. One wide fan-out is right here
+  because deleting is rare and touches more than any edit does.
 - **Pass `{ settle: "record" }`** when the caller is an inline editor. The
   default waits for every affected view to refetch, which is right when the point
   of the action *is* the view changing (a card moving between board columns);

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -122,6 +122,32 @@ Live in `packages/auth/src/workspace.ts`.
 - **`AUTH_COOKIE_DOMAIN`** only when the API and the app are on different
   subdomains of one parent — then `.example.com`, so one cookie covers both. On
   localhost the shared cookie already works, because cookies ignore ports.
+
+### The session cookie is named after this app, not after the library
+
+`AUTH_COOKIE_PREFIX` in [`@crm/auth/cookies`](../packages/auth/src/cookies.ts)
+is the literal string `crm`, so the session cookie is
+`__Secure-crm.session_token` rather than Better Auth's default
+`__Secure-better-auth.session_token`.
+
+The default is a hazard for any install whose app shares a parent domain with
+something else — `crm.example.com` beside an existing `app.example.com`. A
+cookie set with `Domain=.example.com` by the neighbour is sent to *us* too,
+under a name identical to ours, and `parseCookies` keeps one value per name. The
+failure is silent and reads as a deployment problem rather than a naming one:
+sign-in completes, the `session` row is written with a week's expiry, the
+browser holds a cookie, and then every reader — the API that minted it and the
+app alike — resolves it to `null` and bounces to `/sign-in`. Nothing logs an
+error, because nothing has errored.
+
+Two things follow. It is set on the **server config and the proxy's read**
+together: `advanced.cookiePrefix` in `auth.ts` names the cookie and
+`getSessionCookie(request, { cookiePrefix: AUTH_COOKIE_PREFIX })` in
+`apps/app/proxy.ts` looks for it, and a prefix changed in one place only is a
+gate that redirects every signed-in request. And **changing it signs everybody
+out** — the old cookies stop matching. That is a one-time cost paid on deploy,
+not a loop: a stale `better-auth`-prefixed cookie no longer matches, so the
+proxy sends the reader to `/sign-in`, which is where they need to be.
 - **`AGENT_URL`** is the research agent, which is its own deployment. The app
   reads it to proxy the bridge and the API reads it to poke the dispatcher, both
   server-side only: the browser never learns the agent has an origin of its own.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,6 +6,7 @@
 	"exports": {
 		".": "./src/index.ts",
 		"./client": "./src/client.ts",
+		"./cookies": "./src/cookies.ts",
 		"./scopes": "./src/scopes.ts",
 		"./workspace": "./src/workspace.ts"
 	},

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -4,6 +4,7 @@ import { type BetterAuthOptions, betterAuth } from "better-auth";
 import { prismaAdapter } from "better-auth/adapters/prisma";
 import { APIError } from "better-auth/api";
 import { organization } from "better-auth/plugins/organization";
+import { AUTH_COOKIE_PREFIX } from "./cookies";
 import { env } from "./env";
 import { ensureWorkspaceMembership } from "./organization";
 import { SYNC_SCOPES } from "./scopes";
@@ -63,6 +64,8 @@ export const auth = betterAuth({
 	},
 
 	advanced: {
+		cookiePrefix: AUTH_COOKIE_PREFIX,
+
 		useSecureCookies: env.isProduction,
 		...(env.cookieDomain && {
 			crossSubDomainCookies: {

--- a/packages/auth/src/cookies.ts
+++ b/packages/auth/src/cookies.ts
@@ -1,0 +1,1 @@
+export const AUTH_COOKIE_PREFIX = "crm";

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,4 +1,5 @@
 export { type Auth, auth, type Session, type SessionUser } from "./auth";
+export { AUTH_COOKIE_PREFIX } from "./cookies";
 export { isGoogleConfigured } from "./env";
 export {
 	canChangeRole,

--- a/packages/db/prisma/migrations/20260803210000_suppressed_contact/migration.sql
+++ b/packages/db/prisma/migrations/20260803210000_suppressed_contact/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "suppressedContact" (
+    "email" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "suppressedContact_pkey" PRIMARY KEY ("email")
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -603,6 +603,14 @@ model SuppressedDomain {
   @@map("suppressedDomain")
 }
 
+model SuppressedContact {
+  email     String   @id
+  reason    String?
+  createdAt DateTime @default(now())
+
+  @@map("suppressedContact")
+}
+
 model AppSetting {
   id String @id
 


### PR DESCRIPTION
…d deals

- Added delete mutations for companies, contacts, and deals in their respective routers and services.
- Implemented logic to handle the deletion process, including suppression of deleted contacts to prevent re-creation by sync services.
- Updated the API documentation to reflect the new delete functionality and its implications on data integrity.
- Enhanced tests to cover the new delete operations and ensure proper handling of related records.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hard delete for companies, contacts, and deals with a simple UI action and precise activity stamp recomputation to keep timelines accurate. Deleted contacts are suppressed by email so sync won’t recreate them; the sync also ignores machine/infrastructure addresses.

- **New Features**
  - Added `companies.delete`, `contacts.delete`, and `deals.delete` with cleanup (agent tasks/events) and post-commit activity stamp recompute only on affected companies/contacts/deals; deleting a company cascades its deals and leaves its people without a company.
  - Deleted contacts are written to `SuppressedContact`; Gmail/Calendar matching now filters suppressed emails, and adding/updating a contact with that email lifts the suppression. Emails are normalized to lowercase on create/update; matching and un-suppression are case-insensitive.
  - Machine address handling: `isMachineDomain`/`isMachineAddress`; `domainFromEmail` rejects machine domains; participant matching and Calendar attendee parsing drop shared calendars, rooms, sending infra, and opaque IDs.
  - Record sheets get a three-dot Delete action with confirm; uses a new cache `removed()` to refresh lists/timelines without refetching the closing sheet.

- **Bug Fixes**
  - Namespaced the auth session cookie with a `crm` prefix (`AUTH_COOKIE_PREFIX`) and updated the app proxy/dev scripts to read it, avoiding cross-subdomain collisions with neighboring apps.

<sup>Written for commit 68f6014eeb68b3fe863fd81e7cb266e2a309d4d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

