### PR TITLE
style(ui): add wrap-anywhere class to AlertDialog and Dialog components

### DIFF
--- a/packages/ui/src/components/alert-dialog.tsx
+++ b/packages/ui/src/components/alert-dialog.tsx
@@ -99,7 +99,10 @@ function AlertDialogTitle({
 	return (
 		<AlertDialogPrimitive.Title
 			data-slot="alert-dialog-title"
-			className={cn("font-heading text-sm font-medium", className)}
+			className={cn(
+				"font-heading text-sm font-medium wrap-anywhere",
+				className,
+			)}
 			{...props}
 		/>
 	);
@@ -113,7 +116,7 @@ function AlertDialogDescription({
 		<AlertDialogPrimitive.Description
 			data-slot="alert-dialog-description"
 			className={cn(
-				"text-xs/relaxed text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				"text-xs/relaxed text-muted-foreground wrap-anywhere *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
 				className,
 			)}
 			{...props}

--- a/packages/ui/src/components/dialog.tsx
+++ b/packages/ui/src/components/dialog.tsx
@@ -127,7 +127,10 @@ function DialogTitle({
 	return (
 		<DialogPrimitive.Title
 			data-slot="dialog-title"
-			className={cn("font-heading text-sm font-medium", className)}
+			className={cn(
+				"font-heading text-sm font-medium wrap-anywhere",
+				className,
+			)}
 			{...props}
 		/>
 	);
@@ -141,7 +144,7 @@ function DialogDescription({
 		<DialogPrimitive.Description
 			data-slot="dialog-description"
 			className={cn(
-				"text-xs/relaxed text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+				"text-xs/relaxed text-muted-foreground wrap-anywhere *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
 				className,
 			)}
 			{...props}


### PR DESCRIPTION
- Updated AlertDialogTitle and AlertDialogDescription to include the wrap-anywhere class for improved text wrapping.
- Added wrap-anywhere class to DialogTitle and DialogDescription for consistent text handling across dialog components.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `wrap-anywhere` to `AlertDialogTitle`, `AlertDialogDescription`, `DialogTitle`, and `DialogDescription` to wrap long words and URLs. Prevents overflow and makes dialog text more consistent across `packages/ui`.

<sup>Written for commit 59edb6dc13c6fbc0b56ce453d195ad14f338d2a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

