### PR TITLE
Create deno.yml96bf31b72d0c8d8931d124e8670e2fc02601f830

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,0 +1,42 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# This workflow will install Deno then run `deno lint` and `deno test`.
+# For more information see: https://github.com/denoland/setup-deno
+
+name: Deno
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v4
+
+      - name: Setup Deno
+        # uses: denoland/setup-deno@v1
+        uses: denoland/setup-deno@61fe2df320078202e33d7d5ad347e7dcfa0e8f31  # v1.1.2
+        with:
+          deno-version: v1.x
+
+      # Uncomment this step to verify the use of 'deno fmt' on each commit.
+      # - name: Verify formatting
+      #   run: deno fmt --check
+
+      - name: Run linter
+        run: deno lint
+
+      - name: Run tests
+        run: deno test -A


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a GitHub Actions workflow to run Deno linting and tests on pushes and PRs to `main`. This enforces code quality and catches failures in CI.

- **New Features**
  - Added `.github/workflows/deno.yml` running on Ubuntu.
  - Uses `actions/checkout@v4` and pins `denoland/setup-deno` to v1.1.2 (`61fe2d...`) with `deno-version: v1.x`.
  - Runs `deno lint` and `deno test -A`; optional `deno fmt --check` is included but commented.
  - Triggers on `push` and `pull_request` to `main` with minimal `contents: read` permission.

<sup>Written for commit eba74722f6d81f7826fe818983efdf92ce7fb88e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/13?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

