### PR TITLE
feat(api): add native Clay and Claap integrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,6 +126,16 @@ GOOGLE_CLIENT_SECRET=""
 # route. The route refuses to run without it. At least 16 characters.
 # CRON_SECRET=""
 
+# Clay sends qualified rows through an HTTP API column to POST /integrations/clay.
+# Configure that column with Authorization: Bearer <this value>. The endpoint is
+# unavailable when this is unset. At least 16 characters.
+# CLAY_WEBHOOK_SECRET=""
+
+# Claap sends recording_added and recording_updated events to
+# POST /integrations/claap. Paste this value into Claap's webhook secret field.
+# The endpoint is unavailable when this is unset. At least 16 characters.
+# CLAAP_WEBHOOK_SECRET=""
+
 # Log every SQL statement Prisma runs, at debug level, without bound
 # parameters. Off by default: it buries every other line under a wall of
 # SELECTs.

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ short version:
 | `AGENT_BRIDGE_SECRET` | Lets a rep talk to the agent from a contact's **Agent** tab. |
 | `REDIS_URL` | A shared cache. Without it, per-instance and in-memory. |
 | `CRON_SECRET` | Guards the Gmail/Calendar sync route. Required to use it. |
+| `CLAY_WEBHOOK_SECRET` / `CLAAP_WEBHOOK_SECRET` | Enable the [Clay and Claap webhooks](./docs/integrations.md). |
 
 ## Tasks
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { DatabaseModule } from "./database/database.module";
 import { DealsModule } from "./deals/deals.module";
 import { GoogleModule } from "./google/google.module";
 import { HealthModule } from "./health/health.module";
+import { IntegrationsModule } from "./integrations/integrations.module";
 import { LoggingModule } from "./logging/logging.module";
 import { logAuthRoute } from "./logging/request-logger.middleware";
 import { SearchModule } from "./search/search.module";
@@ -39,6 +40,7 @@ import { WorkspaceModule } from "./workspace/workspace.module";
 		BetterAuthModule.forRoot({ auth, middleware: logAuthRoute }),
 		AuthModule,
 		HealthModule,
+		IntegrationsModule,
 		TrpcModule,
 		UsersModule,
 		CompaniesModule,

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -102,6 +102,20 @@ export class EnvironmentVariables {
 	@IsOptional()
 	@IsString()
 	AGENT_BRIDGE_SECRET?: string;
+
+	@IsOptional()
+	@IsString()
+	@MinLength(16, {
+		message: "CLAY_WEBHOOK_SECRET must be at least 16 characters.",
+	})
+	CLAY_WEBHOOK_SECRET?: string;
+
+	@IsOptional()
+	@IsString()
+	@MinLength(16, {
+		message: "CLAAP_WEBHOOK_SECRET must be at least 16 characters.",
+	})
+	CLAAP_WEBHOOK_SECRET?: string;
 }
 
 export function validateEnv(

--- a/apps/api/src/integrations/integration.contracts.ts
+++ b/apps/api/src/integrations/integration.contracts.ts
@@ -1,0 +1,89 @@
+import { DealStage } from "@crm/db";
+import { z } from "zod";
+
+const optionalText = z.string().trim().min(1).optional();
+const email = z
+	.string()
+	.trim()
+	.email()
+	.transform((value) => value.toLowerCase());
+
+export const clayWebhookInput = z.object({
+	eventId: z.string().trim().min(1),
+	ownerEmail: email,
+	list: z.object({ id: optionalText, name: optionalText }).optional(),
+	campaign: z.object({ id: optionalText, name: optionalText }).optional(),
+	company: z.object({
+		name: z.string().trim().min(1),
+		domain: z.string().trim().min(1),
+		website: optionalText,
+		industry: optionalText,
+		linkedinUrl: optionalText,
+	}),
+	contact: z.object({
+		firstName: z.string().trim().min(1),
+		lastName: optionalText,
+		email,
+		phone: optionalText,
+		title: optionalText,
+		linkedinUrl: optionalText,
+	}),
+	opportunity: z
+		.object({
+			name: z.string().trim().min(1),
+			stage: z.nativeEnum(DealStage).optional(),
+			amount: z.coerce.number().nonnegative().optional(),
+			currency: z.string().trim().length(3).toUpperCase().optional(),
+			expectedCloseDate: z.iso.datetime().optional(),
+		})
+		.optional(),
+});
+
+const claapPerson = z.object({
+	email,
+	name: optionalText,
+	attended: z.boolean().optional(),
+});
+
+const claapRecording = z
+	.object({
+		id: z.string().trim().min(1),
+		title: z.string().trim().min(1),
+		createdAt: z.iso.datetime(),
+		url: optionalText,
+		recorder: claapPerson,
+		meeting: z
+			.object({
+				startingAt: z.iso.datetime().optional(),
+				endingAt: z.iso.datetime().optional(),
+				participants: z.array(claapPerson).default([]),
+			})
+			.optional(),
+		crmInfo: z
+			.object({ deal: z.object({ id: z.string().trim().min(1) }).optional() })
+			.optional(),
+		deal: z.object({ id: z.string().trim().min(1) }).optional(),
+		keyTakeaways: z
+			.array(z.object({ text: z.string(), langIso2: optionalText }))
+			.default([]),
+		actionItems: z.array(z.unknown()).default([]),
+		insightTemplates: z.array(z.unknown()).default([]),
+		transcripts: z.array(z.unknown()).default([]),
+	})
+	.passthrough();
+
+const claapEvent = z.object({
+	type: z.enum(["recording_added", "recording_updated"]),
+	recording: claapRecording,
+});
+
+export const claapWebhookInput = z.union([
+	z.object({ eventId: z.string().trim().min(1), event: claapEvent }),
+	claapEvent.transform((event) => ({
+		eventId: `${event.type}:${event.recording.id}`,
+		event,
+	})),
+]);
+
+export type ClayWebhookInput = z.infer<typeof clayWebhookInput>;
+export type ClaapWebhookInput = z.infer<typeof claapWebhookInput>;

--- a/apps/api/src/integrations/integrations.controller.ts
+++ b/apps/api/src/integrations/integrations.controller.ts
@@ -1,0 +1,91 @@
+import {
+	Body,
+	Controller,
+	ForbiddenException,
+	Headers,
+	Post,
+	ServiceUnavailableException,
+	UnprocessableEntityException,
+} from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { AllowAnonymous } from "@thallesp/nestjs-better-auth";
+import type { ZodType } from "zod";
+import type { EnvironmentVariables } from "../config/env.validation";
+import { claapWebhookInput, clayWebhookInput } from "./integration.contracts";
+import { IntegrationsService } from "./integrations.service";
+
+@Controller("integrations")
+export class IntegrationsController {
+	private readonly claySecret: string | undefined;
+	private readonly claapSecret: string | undefined;
+
+	constructor(
+		private readonly integrations: IntegrationsService,
+		config: ConfigService<EnvironmentVariables, true>,
+	) {
+		this.claySecret = config.get("CLAY_WEBHOOK_SECRET", { infer: true });
+		this.claapSecret = config.get("CLAAP_WEBHOOK_SECRET", { infer: true });
+	}
+
+	@Post("clay")
+	@AllowAnonymous()
+	clay(
+		@Headers("authorization") authorization: string | undefined,
+		@Body() body: unknown,
+	) {
+		this.authorize(this.claySecret, bearerToken(authorization));
+		return this.integrations.ingestClay(parse(clayWebhookInput, body));
+	}
+
+	@Post("claap")
+	@AllowAnonymous()
+	claap(
+		@Headers("x-claap-webhook-secret") secret: string | undefined,
+		@Body() body: unknown,
+	) {
+		this.authorize(this.claapSecret, secret);
+		return this.integrations.ingestClaap(parse(claapWebhookInput, body));
+	}
+
+	private authorize(
+		expected: string | undefined,
+		received: string | undefined,
+	) {
+		if (!expected) {
+			throw new ServiceUnavailableException("Integration is not configured.");
+		}
+
+		if (!timingSafeEquals(received ?? "", expected)) {
+			throw new ForbiddenException();
+		}
+	}
+}
+
+function parse<T>(schema: ZodType<T>, body: unknown): T {
+	const result = schema.safeParse(body);
+	if (!result.success) {
+		throw new UnprocessableEntityException({
+			message: "Invalid integration payload.",
+			issues: result.error.issues.map(({ path, message }) => ({
+				path,
+				message,
+			})),
+		});
+	}
+	return result.data;
+}
+
+function timingSafeEquals(a: string, b: string): boolean {
+	if (a.length !== b.length) return false;
+	let mismatch = 0;
+	for (let index = 0; index < a.length; index += 1) {
+		mismatch |= a.charCodeAt(index) ^ b.charCodeAt(index);
+	}
+	return mismatch === 0;
+}
+
+function bearerToken(authorization: string | undefined): string | undefined {
+	return authorization?.startsWith("Bearer ")
+		? authorization.slice("Bearer ".length)
+		: undefined;
+}

--- a/apps/api/src/integrations/integrations.module.ts
+++ b/apps/api/src/integrations/integrations.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { AgentModule } from "../agent/agent.module";
+import { IntegrationsController } from "./integrations.controller";
+import { IntegrationsService } from "./integrations.service";
+
+@Module({
+	imports: [AgentModule],
+	controllers: [IntegrationsController],
+	providers: [IntegrationsService],
+})
+export class IntegrationsModule {}

--- a/apps/api/src/integrations/integrations.service.ts
+++ b/apps/api/src/integrations/integrations.service.ts
@@ -1,0 +1,354 @@
+import {
+	ActivityType,
+	type Db,
+	IntegrationProvider,
+	Prisma,
+	RecordSource,
+} from "@crm/db";
+import { Injectable, UnprocessableEntityException } from "@nestjs/common";
+import { AgentTriggerService } from "../agent/agent-trigger.service";
+import { normalizeDomain } from "../companies/domain";
+import { InjectDatabase } from "../database/database.constants";
+import type {
+	ClaapWebhookInput,
+	ClayWebhookInput,
+} from "./integration.contracts";
+
+type IntegrationResult = {
+	companyId: string | null;
+	contactId: string | null;
+	dealId: string | null;
+	activityId: string;
+};
+
+@Injectable()
+export class IntegrationsService {
+	constructor(
+		@InjectDatabase() private readonly db: Db,
+		private readonly agent: AgentTriggerService,
+	) {}
+
+	async ingestClay(input: ClayWebhookInput): Promise<IntegrationResult> {
+		const delivery = await this.idempotent(
+			IntegrationProvider.CLAY,
+			input.eventId,
+			async () => {
+				const domain = normalizeDomain(input.company.domain);
+				if (!domain) {
+					throw new UnprocessableEntityException(
+						"Clay company domain is invalid.",
+					);
+				}
+
+				return this.db.$transaction(async (tx) => {
+					const owner = await this.userByEmail(tx, input.ownerEmail);
+					const company = await tx.company.upsert({
+						where: { domain },
+						create: {
+							name: input.company.name,
+							domain,
+							website: input.company.website,
+							industry: input.company.industry,
+							linkedinUrl: input.company.linkedinUrl,
+							ownerId: owner.id,
+							source: RecordSource.CLAY,
+						},
+						update: compact({
+							name: input.company.name,
+							website: input.company.website,
+							industry: input.company.industry,
+							linkedinUrl: input.company.linkedinUrl,
+						}),
+						select: { id: true },
+					});
+
+					const contact = await tx.contact.upsert({
+						where: { email: input.contact.email },
+						create: {
+							...input.contact,
+							companyId: company.id,
+							ownerId: owner.id,
+							source: RecordSource.CLAY,
+						},
+						update: compact({
+							firstName: input.contact.firstName,
+							lastName: input.contact.lastName,
+							phone: input.contact.phone,
+							title: input.contact.title,
+							linkedinUrl: input.contact.linkedinUrl,
+							companyId: company.id,
+						}),
+						select: { id: true },
+					});
+
+					const deal = input.opportunity
+						? await tx.deal.create({
+								data: {
+									name: input.opportunity.name,
+									companyId: company.id,
+									ownerId: owner.id,
+									stage: input.opportunity.stage,
+									amount: input.opportunity.amount,
+									currency: input.opportunity.currency,
+									expectedCloseDate: input.opportunity.expectedCloseDate
+										? new Date(input.opportunity.expectedCloseDate)
+										: undefined,
+									contacts: { create: { contactId: contact.id } },
+								},
+								select: { id: true },
+							})
+						: null;
+
+					const activity = await tx.activity.create({
+						data: {
+							type: ActivityType.ENRICHMENT,
+							subject: "Imported from Clay",
+							companyId: company.id,
+							contactId: contact.id,
+							dealId: deal?.id,
+							createdById: owner.id,
+							meta: json({
+								provider: "clay",
+								eventId: input.eventId,
+								list: input.list,
+								campaign: input.campaign,
+							}),
+						},
+						select: { id: true, createdAt: true },
+					});
+
+					await touch(tx, activity.createdAt, {
+						companyId: company.id,
+						contactId: contact.id,
+						dealId: deal?.id ?? null,
+					});
+
+					const integrationResult: IntegrationResult = {
+						companyId: company.id,
+						contactId: contact.id,
+						dealId: deal?.id ?? null,
+						activityId: activity.id,
+					};
+
+					await tx.integrationEvent.create({
+						data: {
+							provider: IntegrationProvider.CLAY,
+							externalId: input.eventId,
+							payload: json(input),
+							result: json(integrationResult),
+						},
+					});
+
+					return integrationResult;
+				});
+			},
+		);
+
+		if (delivery.created) {
+			await Promise.all([
+				this.agent.companyCreated(
+					delivery.result.companyId as string,
+					"Imported from Clay",
+				),
+				this.agent.contactCreated(
+					delivery.result.contactId as string,
+					"Imported from Clay",
+				),
+			]);
+		}
+
+		return delivery.result;
+	}
+
+	async ingestClaap(input: ClaapWebhookInput): Promise<IntegrationResult> {
+		const delivery = await this.idempotent(
+			IntegrationProvider.CLAAP,
+			input.eventId,
+			async () => {
+				const { event } = input;
+				return this.db.$transaction(async (tx) => {
+					const author = await this.userByEmail(
+						tx,
+						event.recording.recorder.email,
+					);
+					const emails = [
+						...new Set(
+							(event.recording.meeting?.participants ?? []).map(
+								(participant) => participant.email,
+							),
+						),
+					];
+					const contacts = await tx.contact.findMany({
+						where: { email: { in: emails, mode: "insensitive" } },
+						select: { id: true, companyId: true },
+					});
+					const explicitDealId =
+						event.recording.crmInfo?.deal?.id ?? event.recording.deal?.id;
+					const deal = explicitDealId
+						? await tx.deal.findUnique({
+								where: { id: explicitDealId },
+								select: { id: true, companyId: true },
+							})
+						: null;
+					const companyIds = new Set(
+						contacts.flatMap((contact) =>
+							contact.companyId ? [contact.companyId] : [],
+						),
+					);
+					const companyId =
+						deal?.companyId ??
+						(companyIds.size === 1 ? ([...companyIds][0] as string) : null);
+					const contactId =
+						contacts.length === 1 ? (contacts[0]?.id ?? null) : null;
+					const occurredAt = new Date(
+						event.recording.meeting?.startingAt ?? event.recording.createdAt,
+					);
+					const body = event.recording.keyTakeaways
+						.map((takeaway) => takeaway.text.trim())
+						.filter(Boolean)
+						.join("\n\n");
+
+					const activity = await tx.activity.create({
+						data: {
+							type: ActivityType.MEETING,
+							subject: event.recording.title,
+							body: body || null,
+							occurredAt,
+							companyId,
+							contactId,
+							dealId: deal?.id,
+							createdById: author.id,
+							meta: json({
+								provider: "claap",
+								eventId: input.eventId,
+								recordingId: event.recording.id,
+								recordingUrl: event.recording.url,
+								participants: event.recording.meeting?.participants ?? [],
+								actionItems: event.recording.actionItems,
+								insightTemplates: event.recording.insightTemplates,
+								transcripts: event.recording.transcripts,
+							}),
+						},
+						select: { id: true, createdAt: true },
+					});
+
+					await touch(tx, activity.createdAt, {
+						companyId,
+						contactId,
+						dealId: deal?.id ?? null,
+					});
+
+					const integrationResult: IntegrationResult = {
+						companyId,
+						contactId,
+						dealId: deal?.id ?? null,
+						activityId: activity.id,
+					};
+
+					await tx.integrationEvent.create({
+						data: {
+							provider: IntegrationProvider.CLAAP,
+							externalId: input.eventId,
+							payload: json(input),
+							result: json(integrationResult),
+						},
+					});
+
+					return integrationResult;
+				});
+			},
+		);
+
+		return delivery.result;
+	}
+
+	private async idempotent(
+		provider: IntegrationProvider,
+		externalId: string,
+		create: () => Promise<IntegrationResult>,
+	): Promise<{ result: IntegrationResult; created: boolean }> {
+		const previous = await this.previous(provider, externalId);
+		if (previous) return { result: previous, created: false };
+
+		try {
+			return { result: await create(), created: true };
+		} catch (error) {
+			if (
+				error instanceof Prisma.PrismaClientKnownRequestError &&
+				error.code === "P2002"
+			) {
+				const concurrent = await this.previous(provider, externalId);
+				if (concurrent) return { result: concurrent, created: false };
+			}
+			throw error;
+		}
+	}
+
+	private async previous(
+		provider: IntegrationProvider,
+		externalId: string,
+	): Promise<IntegrationResult | null> {
+		const event = await this.db.integrationEvent.findUnique({
+			where: { provider_externalId: { provider, externalId } },
+			select: { result: true },
+		});
+		return event?.result as IntegrationResult | null;
+	}
+
+	private async userByEmail(tx: Prisma.TransactionClient, email: string) {
+		const user = await tx.user.findFirst({
+			where: { email: { equals: email, mode: "insensitive" } },
+			select: { id: true },
+		});
+		if (!user) {
+			throw new UnprocessableEntityException(
+				`No CRM user matches integration owner ${email}.`,
+			);
+		}
+		return user;
+	}
+}
+
+function compact<T extends Record<string, unknown>>(value: T): T {
+	return Object.fromEntries(
+		Object.entries(value).filter(([, entry]) => entry !== undefined),
+	) as T;
+}
+
+function json(value: unknown): Prisma.InputJsonValue {
+	return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}
+
+async function touch(
+	tx: Prisma.TransactionClient,
+	at: Date,
+	target: {
+		companyId: string | null;
+		contactId: string | null;
+		dealId: string | null;
+	},
+) {
+	const stale = {
+		OR: [{ lastActivityAt: null }, { lastActivityAt: { lt: at } }],
+	};
+	await Promise.all([
+		target.companyId
+			? tx.company.updateMany({
+					where: { id: target.companyId, ...stale },
+					data: { lastActivityAt: at },
+				})
+			: null,
+		target.contactId
+			? tx.contact.updateMany({
+					where: { id: target.contactId, ...stale },
+					data: { lastActivityAt: at },
+				})
+			: null,
+		target.dealId
+			? tx.deal.updateMany({
+					where: { id: target.dealId, ...stale },
+					data: { lastActivityAt: at },
+				})
+			: null,
+	]);
+}

--- a/apps/api/test/integration-contracts.spec.ts
+++ b/apps/api/test/integration-contracts.spec.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import {
+	claapWebhookInput,
+	clayWebhookInput,
+} from "../src/integrations/integration.contracts";
+
+describe("Clay integration payload", () => {
+	it("normalizes emails and currency", () => {
+		const parsed = clayWebhookInput.parse({
+			eventId: "row-1",
+			ownerEmail: "Owner@Acme.com",
+			company: { name: "Acme", domain: "acme.com" },
+			contact: { firstName: "Jane", email: "Jane@Customer.com" },
+			opportunity: { name: "Acme expansion", currency: "eur" },
+		});
+
+		expect(parsed.ownerEmail).toBe("owner@acme.com");
+		expect(parsed.contact.email).toBe("jane@customer.com");
+		expect(parsed.opportunity?.currency).toBe("EUR");
+	});
+
+	it("requires explicit company and contact identity", () => {
+		const parsed = clayWebhookInput.safeParse({
+			eventId: "row-1",
+			ownerEmail: "owner@acme.com",
+		});
+
+		expect(parsed.success).toBe(false);
+	});
+});
+
+describe("Claap integration payload", () => {
+	const event = {
+		type: "recording_added",
+		recording: {
+			id: "recording-1",
+			title: "Discovery",
+			createdAt: "2026-08-04T01:00:00.000Z",
+			recorder: { email: "Rep@Acme.com" },
+			meeting: {
+				participants: [{ email: "Buyer@Customer.com" }],
+			},
+		},
+	};
+
+	it("accepts the documented event envelope", () => {
+		const parsed = claapWebhookInput.parse({ eventId: "delivery-1", event });
+
+		expect(parsed.eventId).toBe("delivery-1");
+		expect(parsed.event.recording.recorder.email).toBe("rep@acme.com");
+		expect(parsed.event.recording.meeting?.participants[0]?.email).toBe(
+			"buyer@customer.com",
+		);
+	});
+
+	it("derives a stable id for the unwrapped event shape", () => {
+		const parsed = claapWebhookInput.parse(event);
+
+		expect(parsed.eventId).toBe("recording_added:recording-1");
+	});
+});

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -346,6 +346,17 @@ Two things to do in Google Cloud before this works:
 The cron is declared in `apps/api/vercel.json` at `*/5 * * * *`. Minute-level
 schedules need a Pro plan; on Hobby it silently becomes daily.
 
+## Clay and Claap webhooks
+
+`CLAY_WEBHOOK_SECRET` and `CLAAP_WEBHOOK_SECRET` independently enable the two
+inbound integration routes. Each is optional; an unset secret makes only its route
+return `503`, and the rest of the CRM continues to work. Both must be at least 16
+characters.
+
+Clay sends the secret as a bearer token. Claap sends its configured secret in
+`X-Claap-Webhook-Secret`. Payloads, setup and exact matching rules are documented in
+[`docs/integrations.md`](./integrations.md).
+
 ## Database
 
 Prisma is driven through turbo from the repo root: `db:generate`, `db:migrate`,

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,81 @@
+# Clay and Claap
+
+Both integrations are inbound webhooks. They are disabled unless their independent
+root environment secret is set, record every accepted event in `integrationEvent`,
+and return the result of the first delivery for retries with the same event id.
+
+The API only makes exact, deterministic matches. It never guesses a company, contact,
+deal or owner. Clay supplies the records to write explicitly. Claap participants match
+contacts by email, its recorder matches a CRM user by email, and a deal is attached
+only when Claap sends the CRM deal id.
+
+## Clay
+
+Set `CLAY_WEBHOOK_SECRET`, then add an HTTP API enrichment column in Clay:
+
+- method: `POST`
+- endpoint: `https://<api-host>/integrations/clay`
+- header: `Authorization: Bearer <CLAY_WEBHOOK_SECRET>`
+- body:
+
+```json
+{
+  "eventId": "/CRM Event ID",
+  "ownerEmail": "owner@acme.com",
+  "list": { "id": "/List ID", "name": "/List Name" },
+  "campaign": { "id": "/Campaign ID", "name": "/Campaign Name" },
+  "company": {
+    "name": "/Company Name",
+    "domain": "/Company Domain",
+    "website": "/Company Website",
+    "industry": "/Industry",
+    "linkedinUrl": "/Company LinkedIn URL"
+  },
+  "contact": {
+    "firstName": "/First Name",
+    "lastName": "/Last Name",
+    "email": "/Work Email",
+    "phone": "/Phone",
+    "title": "/Job Title",
+    "linkedinUrl": "/LinkedIn URL"
+  },
+  "opportunity": {
+    "name": "/Opportunity Name",
+    "stage": "DEMO_BOOKED",
+    "amount": "/Amount",
+    "currency": "USD",
+    "expectedCloseDate": "/Expected Close Date"
+  }
+}
+```
+
+`eventId`, `ownerEmail`, `company.name`, `company.domain`, `contact.firstName` and
+`contact.email` are required. `ownerEmail` must exactly match a CRM user. Omit
+`opportunity` to import only the company and contact. A successful import upserts the
+company by domain and the contact by email, creates the optional deal, writes an
+enrichment activity with the Clay list and campaign, and queues the normal company
+and contact agent work.
+
+Use a value that is unique to the intended delivery for `eventId`, such as a formula
+combining the Clay row id with its revision. Reusing the exact value for a retry
+deliberately returns the original result without writing a duplicate.
+
+## Claap
+
+Set `CLAAP_WEBHOOK_SECRET`, create a Claap webhook pointing to
+`https://<api-host>/integrations/claap`, and use the same value as the webhook secret.
+Subscribe to `recording_added` and `recording_updated`.
+
+The endpoint accepts Claap's envelope containing `eventId` and `event`, and the
+unwrapped event shape used by older webhook configurations. Claap's event id is the
+idempotency key. For an unwrapped event, the key is `<event type>:<recording id>`.
+
+The recording's `recorder.email` must exactly match a CRM user so the activity has an
+honest author. Participant emails are matched to existing contacts; no new contacts
+are inferred from a meeting. One matching contact is attached directly. A company is
+attached when all matching contacts point to the same company. A deal is attached
+only when `crmInfo.deal.id` or `deal.id` is an existing CRM deal id.
+
+The meeting activity stores the title, time, takeaways, recording URL, participants,
+action items, insights and transcript links. Ambiguous participant matches stay in
+the activity metadata instead of being forced onto one contact.

--- a/packages/db/prisma/migrations/20260804010000_native_integrations/migration.sql
+++ b/packages/db/prisma/migrations/20260804010000_native_integrations/migration.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "IntegrationProvider" AS ENUM ('CLAY', 'CLAAP');
+
+ALTER TYPE "RecordSource" ADD VALUE 'CLAY';
+
+CREATE TABLE "integrationEvent" (
+    "id" TEXT NOT NULL,
+    "provider" "IntegrationProvider" NOT NULL,
+    "externalId" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "result" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "integrationEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "integrationEvent_provider_externalId_key" ON "integrationEvent"("provider", "externalId");
+CREATE INDEX "integrationEvent_createdAt_idx" ON "integrationEvent"("createdAt");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -133,6 +133,25 @@ enum RecordSource {
   IMPORT
   EMAIL
   CALENDAR
+  CLAY
+}
+
+enum IntegrationProvider {
+  CLAY
+  CLAAP
+}
+
+model IntegrationEvent {
+  id         String              @id @default(cuid())
+  provider   IntegrationProvider
+  externalId String
+  payload    Json
+  result     Json
+  createdAt  DateTime            @default(now())
+
+  @@unique([provider, externalId])
+  @@index([createdAt])
+  @@map("integrationEvent")
 }
 
 model Company {


### PR DESCRIPTION
## What changed

- add authenticated inbound endpoints for Clay and Claap
- upsert Clay companies and contacts, optionally create a deal, record provenance, and queue existing agent work
- create Claap meeting activities with exact participant, company, deal, and author matching
- persist webhook deliveries with concurrency-safe idempotency
- add the Prisma migration, environment validation, payload contracts, tests, and setup documentation

## Why

Clay is commonly the qualification and enrichment layer before a CRM, while Claap contains the meeting context needed after a sales call. These endpoints let the CRM act as the operational hub without moving vendor intelligence into the Nest API.

All matching is deterministic: Clay sends explicit records and an owner email; Claap uses exact CRM ids and email addresses. Ambiguous data remains in activity metadata instead of being guessed onto a CRM record.

## Impact

Both integrations remain disabled unless their independent webhook secret is configured. Existing installs continue to work without either secret. Accepted deliveries are recorded so vendor retries do not duplicate CRM records or activities.

## Validation

- API TypeScript check passed
- Prisma schema validation passed
- Biome passed for every changed TypeScript file
- Clay and Claap contract smoke tests passed through `tsx`
- `git diff --check` passed

The Bun test suite was not run locally because Windows blocked execution of the downloaded Bun binary. Contract tests are included for CI.

Closes #1


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native inbound Clay and Claap integrations with authenticated webhooks to upsert CRM records and create meeting activities with deterministic matching and idempotent delivery. Both integrations are off by default and require provider-specific secrets, so existing installs keep working.

- New Features
  - Added POST `/integrations/clay` (Bearer auth) and `/integrations/claap` (`X-Claap-Webhook-Secret`) endpoints.
  - Clay: upserts company by domain and contact by email, optionally creates a deal, records provenance, and triggers agent work.
  - Claap: creates a meeting activity (title, time, takeaways, recording URL) with exact author, participant, company, and deal matching.
  - Persisted webhook deliveries in `integrationEvent` with concurrency-safe idempotency, returning the first result on retries.
  - Added env validation, docs, and payload contracts; module wired into the API.

- Migration
  - Run Prisma migrate.
  - Set `CLAY_WEBHOOK_SECRET` and/or `CLAAP_WEBHOOK_SECRET` (≥16 chars). Endpoints return 503 when unset.
  - Configure Clay HTTP API column: POST to `/integrations/clay` with `Authorization: Bearer <CLAY_WEBHOOK_SECRET>`.
  - Configure Claap webhook: POST to `/integrations/claap` with `X-Claap-Webhook-Secret: <CLAAP_WEBHOOK_SECRET>`.

<sup>Written for commit 1ba48bbcda4c37500016236bbe7cf49e4e3c213c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

