### PR TITLE
docs(adrs): add first-pr contributor playbook

### DIFF
--- a/adrs/contributor-first-pr-playbook.md
+++ b/adrs/contributor-first-pr-playbook.md
@@ -10,11 +10,11 @@ What I would add is a short first-PR checklist focused on this repository:
 - Keep intelligence in apps/agent, not apps/api.
 - Treat packages/ui as the only source of UI components and style variants.
 - Use the root environment model only; no per-package env files.
-- Run check-types, lint, and test before pushing.
+- Run bun run check-types, bun run lint, and bun run test before pushing.
 - Use a conventional commit subject that reads well in changelog history.
 
 I would also include a recommended first PR shape: one docs or ADR improvement, or one narrow bug fix with tests, rather than a redesign. This aligns with how this repo is reviewed and keeps merge risk low for a first contribution.
 
-What this could break is very small: if this playbook drifts from other docs, it becomes duplicate policy text. To avoid that, the playbook should point contributors to CONTRIBUTING and the docs folder as source of truth and stay intentionally short.
+What this could break is very small: if this playbook drifts from other docs, it becomes duplicate policy text. To avoid that, the playbook should point contributors to [CONTRIBUTING](../CONTRIBUTING.md), [Design rules](../docs/design.md), [API rules](../docs/api.md), [Agent rules](../docs/agent.md), and [Environment rules](../docs/environment.md) as source of truth and stay intentionally short.
 
 If this direction sounds right, the follow-up is to either keep this ADR as guidance, or promote it into a short section in CONTRIBUTING after maintainer review.

--- a/adrs/contributor-first-pr-playbook.md
+++ b/adrs/contributor-first-pr-playbook.md
@@ -1,0 +1,20 @@
+# Contributor first PR playbook
+
+I want to propose a tiny playbook for first-time contributors, because the current docs are good but still easy to misread when you are new to this repo. The confusion is not about tooling basics, it is about repo-specific boundaries: where intelligence is allowed to live, which UI layer owns styles, and what kind of PR maintainers can review quickly.
+
+The case that made me notice this: a contributor can follow standard GitHub flow perfectly and still open a PR that gets slowed down by avoidable feedback like scope is too wide, this belongs in the agent not API, or this style belongs in packages/ui not the app. None of that is obvious from generic open source habits, and first-time contributors should not have to discover it only after review.
+
+What I would add is a short first-PR checklist focused on this repository:
+- Choose a small, single-purpose change.
+- Lead with why in the PR description.
+- Keep intelligence in apps/agent, not apps/api.
+- Treat packages/ui as the only source of UI components and style variants.
+- Use the root environment model only; no per-package env files.
+- Run check-types, lint, and test before pushing.
+- Use a conventional commit subject that reads well in changelog history.
+
+I would also include a recommended first PR shape: one docs or ADR improvement, or one narrow bug fix with tests, rather than a redesign. This aligns with how this repo is reviewed and keeps merge risk low for a first contribution.
+
+What this could break is very small: if this playbook drifts from other docs, it becomes duplicate policy text. To avoid that, the playbook should point contributors to CONTRIBUTING and the docs folder as source of truth and stay intentionally short.
+
+If this direction sounds right, the follow-up is to either keep this ADR as guidance, or promote it into a short section in CONTRIBUTING after maintainer review.


### PR DESCRIPTION
## What does this PR do?
Adds a short ADR playbook for first-time contributors in this repository.

## Why?
Contributors can follow standard GitHub flow and still hit repo-specific review blockers (scope too broad, wrong layer ownership, missing local checks). This playbook reduces avoidable review churn by documenting the first-PR path specific to this repo.

## Changes
- Added drs/contributor-first-pr-playbook.md
- Covered first-PR scope, workflow boundaries, and local validation checklist
- Kept guidance concise and aligned to existing repo docs

## Validation
- [x] Docs-only change
- [x] Focused single-file diff
- [ ] bun run check-types
- [ ] bun run lint
- [ ] bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an ADR with a short playbook for first-time contributors to this repo. It clarifies safe first-PR scope, repo layer boundaries (`apps/agent` vs `apps/api`, UI in `packages/ui`), root env usage, the exact pre-push commands (`bun run check-types`, `bun run lint`, `bun run test`), and links to the source docs for CONTRIBUTING, design, API, agent, and environment.

<sup>Written for commit 41c91f53fa8dd0c79c5b1dfe24a1aa858ff69029. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

