### PR TITLE
feat(api): trigger agent refresh on contact and deal changes

### DIFF
--- a/apps/api/src/agent/agent-trigger.service.ts
+++ b/apps/api/src/agent/agent-trigger.service.ts
@@ -1,4 +1,4 @@
-import type { Db } from "@crm/db";
+import type { Db, DealStage } from "@crm/db";
 import { PRIORITY } from "@crm/db/agent-tasks";
 import { Injectable, Logger } from "@nestjs/common";
 import { InjectDatabase } from "../database/database.constants";
@@ -98,7 +98,7 @@ export class AgentTriggerService {
 
 	async dealStageChanged(
 		companyId: string,
-		stage: string,
+		stage: DealStage,
 		reason = "Deal stage changed",
 	): Promise<void> {
 		await this.enqueue({

--- a/apps/api/src/agent/agent-trigger.service.ts
+++ b/apps/api/src/agent/agent-trigger.service.ts
@@ -70,6 +70,46 @@ export class AgentTriggerService {
 		});
 	}
 
+	async contactUpdated(
+		contactId: string,
+		reason = "A rep updated this contact",
+	): Promise<void> {
+		await this.enqueue({
+			contactId,
+			kind: "profile",
+			reason,
+			priority: PRIORITY.requested,
+			budget: 6,
+		});
+	}
+
+	async dealCreated(
+		companyId: string,
+		reason = "A new deal was created",
+	): Promise<void> {
+		await this.enqueue({
+			companyId,
+			kind: "company-profile",
+			reason,
+			priority: PRIORITY.requested,
+			budget: 8,
+		});
+	}
+
+	async dealStageChanged(
+		companyId: string,
+		stage: string,
+		reason = "Deal stage changed",
+	): Promise<void> {
+		await this.enqueue({
+			companyId,
+			kind: "company-profile",
+			reason: `${reason} (${stage})`,
+			priority: PRIORITY.requested,
+			budget: 6,
+		});
+	}
+
 	async meetingSoon(contactId: string, when: Date): Promise<void> {
 		await this.enqueue({
 			contactId,

--- a/apps/api/src/contacts/contacts.service.ts
+++ b/apps/api/src/contacts/contacts.service.ts
@@ -391,7 +391,7 @@ export class ContactsService {
 		}
 
 		try {
-			return await this.db.$transaction(async (tx) => {
+			const updated = await this.db.$transaction(async (tx) => {
 				const updated = await tx.contact.update({
 					where: { id },
 					data,
@@ -404,6 +404,15 @@ export class ContactsService {
 
 				return updated;
 			});
+
+			if (Object.keys(data).length > 0) {
+				await this.agent.contactUpdated(
+					updated.id,
+					"A rep changed contact details",
+				);
+			}
+
+			return updated;
 		} catch (error) {
 			throw this.translate(error, id);
 		}

--- a/apps/api/src/deals/deals.module.ts
+++ b/apps/api/src/deals/deals.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { AgentModule } from "../agent/agent.module";
 import { TrpcModule } from "../trpc/trpc.module";
 import { DealsRouter } from "./deals.router";
 import { DealsService } from "./deals.service";
 
 @Module({
-	imports: [TrpcModule],
+	imports: [TrpcModule, AgentModule],
 	providers: [DealsService, DealsRouter],
 	exports: [DealsService],
 })

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -11,13 +11,13 @@ import {
 	Logger,
 	NotFoundException,
 } from "@nestjs/common";
+import { AgentTriggerService } from "../agent/agent-trigger.service";
 import {
 	ActivityStampService,
 	type StampTargets,
 } from "../crm/activity-stamp.service";
 import { fromCents, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
-import { AgentTriggerService } from "../agent/agent-trigger.service";
 import {
 	countsByKey,
 	FACET_ALL,
@@ -196,8 +196,8 @@ export class DealsService {
 		const closed = isClosedStage(stage);
 		const now = new Date();
 
-		try {
-			const deal = await this.db.deal.create({
+		const deal = await this.db.deal
+			.create({
 				data: {
 					name: input.name.trim(),
 					companyId: input.companyId,
@@ -210,19 +210,19 @@ export class DealsService {
 					expectedCloseDate: parseDate(input.expectedCloseDate),
 				},
 				select: { id: true, name: true, companyId: true },
+			})
+			.catch((error) => {
+				throw this.translateRelations(error);
 			});
 
-			this.logger.log({ message: "Deal created", dealId: deal.id, stage });
+		this.logger.log({ message: "Deal created", dealId: deal.id, stage });
 
-			await this.agent.dealCreated(
-				deal.companyId,
-				"A new deal was added to this account",
-			);
+		await this.agent.dealCreated(
+			deal.companyId,
+			"A new deal was added to this account",
+		);
 
-			return deal;
-		} catch (error) {
-			throw this.translateRelations(error);
-		}
+		return deal;
 	}
 
 	async update(id: string, input: DealUpdateInput) {

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -17,6 +17,7 @@ import {
 } from "../crm/activity-stamp.service";
 import { fromCents, toCents } from "../crm/values";
 import { InjectDatabase } from "../database/database.constants";
+import { AgentTriggerService } from "../agent/agent-trigger.service";
 import {
 	countsByKey,
 	FACET_ALL,
@@ -79,6 +80,7 @@ export class DealsService {
 
 	constructor(
 		@InjectDatabase() private readonly db: Db,
+		private readonly agent: AgentTriggerService,
 		private readonly stamp: ActivityStampService,
 	) {}
 
@@ -212,6 +214,11 @@ export class DealsService {
 
 			this.logger.log({ message: "Deal created", dealId: deal.id, stage });
 
+			await this.agent.dealCreated(
+				deal.companyId,
+				"A new deal was added to this account",
+			);
+
 			return deal;
 		} catch (error) {
 			throw this.translateRelations(error);
@@ -336,6 +343,12 @@ export class DealsService {
 			from: deal.stage,
 			to: input.stage,
 		});
+
+		await this.agent.dealStageChanged(
+			deal.companyId,
+			input.stage,
+			"Deal stage moved",
+		);
 
 		return { ...updated, changed: true };
 	}

--- a/apps/api/test/agent-trigger.spec.ts
+++ b/apps/api/test/agent-trigger.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import { db } from "@crm/db";
 import { PRIORITY } from "@crm/db/agent-tasks";
 import { AgentTriggerService } from "../src/agent/agent-trigger.service";
@@ -8,14 +8,23 @@ const reasonPrefix = `agent-trigger-spec (${suffix})`;
 
 const service = new AgentTriggerService(db);
 
-beforeEach(async () => {
-	await db.agentTask.deleteMany({
+const cleanup = () =>
+	db.agentTask.deleteMany({
 		where: {
-			reason: {
-				contains: reasonPrefix,
-			},
+			OR: [
+				{ reason: { contains: reasonPrefix } },
+				{ contactId: { startsWith: `contact-${suffix}-` } },
+				{ companyId: { startsWith: `company-${suffix}-` } },
+			],
 		},
 	});
+
+beforeEach(async () => {
+	await cleanup();
+});
+
+afterAll(async () => {
+	await cleanup();
 });
 
 describe("AgentTriggerService", () => {

--- a/apps/api/test/agent-trigger.spec.ts
+++ b/apps/api/test/agent-trigger.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { db } from "@crm/db";
+import { PRIORITY } from "@crm/db/agent-tasks";
+import { AgentTriggerService } from "../src/agent/agent-trigger.service";
+
+const suffix = process.env.TEST_RUN_ID ?? "agent-trigger-spec";
+const reasonPrefix = `agent-trigger-spec (${suffix})`;
+
+const service = new AgentTriggerService(db);
+
+beforeEach(async () => {
+	await db.agentTask.deleteMany({
+		where: {
+			reason: {
+				contains: reasonPrefix,
+			},
+		},
+	});
+});
+
+describe("AgentTriggerService", () => {
+	it("queues a profile task when a contact is updated", async () => {
+		const contactId = `contact-${suffix}-1`;
+
+		await service.contactUpdated(
+			contactId,
+			`${reasonPrefix}: contact-updated`,
+		);
+
+		const task = await db.agentTask.findFirst({
+			where: {
+				contactId,
+				kind: "profile",
+			},
+			orderBy: { createdAt: "desc" },
+		});
+
+		expect(task).not.toBeNull();
+		expect(task?.priority).toBe(PRIORITY.requested);
+		expect(task?.budget).toBe(6);
+	});
+
+	it("does not queue duplicate profile tasks while one is pending", async () => {
+		const contactId = `contact-${suffix}-2`;
+
+		await service.contactUpdated(
+			contactId,
+			`${reasonPrefix}: contact-updated-duplicate`,
+		);
+		await service.contactUpdated(
+			contactId,
+			`${reasonPrefix}: contact-updated-duplicate`,
+		);
+
+		const count = await db.agentTask.count({
+			where: {
+				contactId,
+				kind: "profile",
+				finishedAt: null,
+			},
+		});
+
+		expect(count).toBe(1);
+	});
+
+	it("queues one company profile task for deal events while pending", async () => {
+		const companyId = `company-${suffix}-1`;
+
+		await service.dealCreated(companyId, `${reasonPrefix}: deal-created`);
+		await service.dealStageChanged(
+			companyId,
+			"DEMO_BOOKED",
+			`${reasonPrefix}: deal-stage-changed`,
+		);
+
+		const tasks = await db.agentTask.findMany({
+			where: {
+				companyId,
+				kind: "company-profile",
+				finishedAt: null,
+			},
+		});
+
+		expect(tasks).toHaveLength(1);
+		expect(tasks[0]?.priority).toBe(PRIORITY.requested);
+	});
+});

--- a/apps/api/test/record-delete.spec.ts
+++ b/apps/api/test/record-delete.spec.ts
@@ -23,6 +23,7 @@ const stamp = new ActivityStampService(db);
 
 const agent = {
 	contactCreated: async () => undefined,
+	contactUpdated: async () => undefined,
 	companyCreated: async () => undefined,
 	companyRequested: async () => undefined,
 } as unknown as AgentTriggerService;


### PR DESCRIPTION
## What does this PR do?

Wires additional API lifecycle events into `AgentTriggerService` so agent refresh tasks are queued when contacts and deals change.

## Why?

This keeps CRM records fresher without adding intelligence to the API layer. Nest reports that something happened and the agent decides what it means, which matches the architecture rule in `docs/api.md`.

## Changes

- Added new trigger methods in `AgentTriggerService`:
  - `contactUpdated()` queues a `profile` task
  - `dealCreated()` queues a `company-profile` task
  - `dealStageChanged()` queues a `company-profile` task
- Wired `ContactsService.update()` to trigger a contact refresh when details actually change
- Wired `DealsService.create()` and `DealsService.setStage()` to trigger a company refresh
- Updated `DealsModule` to import `AgentModule` for dependency wiring
- Added `apps/api/test/agent-trigger.spec.ts` covering queueing and de-duplication

## Validation

- [x] Editor diagnostics clean for every changed file
- [x] Existing `enqueue()` de-duplication reused, so repeated events do not stack tasks
- [ ] `bun run check-types`
- [ ] `bun run lint`
- [ ] `bun run test`

The three unchecked boxes are the local Bun toolchain, which is not installed on the machine this branch was written on. Happy to push a follow-up commit if CI surfaces anything.

## Notes

Scope is deliberately limited to event-to-task wiring and its test coverage. No enrichment logic, no schema change, no new environment variable.
