### PR TITLE
Refactor isActive function and update SheetHeader

### DIFF
--- a/apps/app/components/app-icon-rail.tsx
+++ b/apps/app/components/app-icon-rail.tsx
@@ -45,10 +45,10 @@ const ITEMS: RailItem[] = [
 ];
 
 function isActive(item: RailItem, pathname: string): boolean {
-	return (
-		pathname === item.href ||
-		(item.match === "prefix" && pathname.startsWith(item.href))
-	);
+	if (item.match === "exact" || item.href === "/") {
+		return pathname === item.href;
+	}
+	return pathname === item.href || pathname.startsWith(`${item.href}/`);
 }
 
 function RailLink({ item, active }: { item: RailItem; active: boolean }) {
@@ -68,7 +68,6 @@ function RailLink({ item, active }: { item: RailItem; active: boolean }) {
 					<Link
 						href={item.href}
 						aria-current={active ? "page" : undefined}
-						transitionTypes={["nav-lateral"]}
 					>
 						<Icon icon={item.icon} />
 						<span className="sr-only">{item.title}</span>
@@ -132,8 +131,8 @@ export function AppIconRail() {
 
 			<Sheet open={open} onOpenChange={setOpen}>
 				<SheetContent side="left" className="w-64 gap-0 p-0">
-					<SheetHeader>
-						<SheetTitle>Navigation</SheetTitle>
+					<SheetHeader className="border-b p-4 text-left">
+						<SheetTitle className="text-base font-semibold">Navigation</SheetTitle>
 					</SheetHeader>
 					<nav aria-label="Primary" className="flex flex-1 flex-col gap-1 p-2">
 						{ITEMS.map((item) => (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored the active-route logic to handle exact routes (including “/”) and nested paths correctly in the app icon rail. Removed the unused `transitionTypes` prop on the link and updated the `SheetHeader` with a border, padding, and a left-aligned, smaller title.

<sup>Written for commit 56d8acceb15ecc6d334a6f2a1a312409c9e4b20a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/23?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

