### PR TITLE
refactor(landing): remove unused Link imports from agent and capabili…

### DIFF
--- a/apps/app/components/landing/agent-section.tsx
+++ b/apps/app/components/landing/agent-section.tsx
@@ -8,7 +8,6 @@ import Time from "@carbon/icons-react/es/Time";
 import SlackLogo from "@crm/ui/components/brand-logos/slack";
 import { cn } from "@crm/ui/lib/utils";
 import Image from "next/image";
-import Link from "next/link";
 import type * as React from "react";
 import { Chip } from "./chip";
 import { SectionHeading } from "./section-heading";

--- a/apps/app/components/landing/capabilities-section.tsx
+++ b/apps/app/components/landing/capabilities-section.tsx
@@ -3,7 +3,6 @@ import GitHubLogo from "@crm/ui/components/brand-logos/github";
 import StripeLogo from "@crm/ui/components/brand-logos/stripe";
 import VercelLogo from "@crm/ui/components/brand-logos/vercel";
 import { cn } from "@crm/ui/lib/utils";
-import Link from "next/link";
 import type * as React from "react";
 import { AskCard } from "./ask-card";
 import {


### PR DESCRIPTION
…ties sections

- Eliminated Link imports from the agent-section and capabilities-section components to streamline the codebase and improve maintainability.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused imports from the landing page to clean up code and remove lint warnings.

- Removed `Link` from `next/link` in `agent-section.tsx` and `capabilities-section.tsx`. No behavior or UI changes.

<sup>Written for commit 66213dd2dec88954a831771ccb087f78ce7d7e20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

