### PR TITLE
Lewis/lp gate

### DIFF
--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -28,7 +28,7 @@ export async function proxy(request: NextRequest) {
 	) {
 		return isPublic(pathname)
 			? NextResponse.next()
-			: NextResponse.redirect(new URL(SIGN_IN_PATH, request.nextUrl));
+			: sendTo(SIGN_IN_PATH, request);
 	}
 
 	if (isUngated(pathname)) return NextResponse.next();

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -14,21 +14,21 @@ const LANDING_PATH = "/";
 
 const SIGN_IN_PATH = "/sign-in";
 
-const PUBLIC = [SIGN_IN_PATH];
-
-const UNGATED = [SIGN_IN_PATH, "/grant-access", "/eve"];
+const UNGATED = ["/grant-access", "/eve"];
 
 const SECTIONS = ["/companies", "/contacts", "/deals", "/settings"];
 
 export async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
+	if (pathname === SIGN_IN_PATH) return NextResponse.next();
+
 	if (
 		getSessionCookie(request, { cookiePrefix: AUTH_COOKIE_PREFIX }) === null
 	) {
 		return isPublic(pathname)
 			? NextResponse.next()
-			: sendTo(SIGN_IN_PATH, request);
+			: NextResponse.redirect(new URL(SIGN_IN_PATH, request.nextUrl));
 	}
 
 	if (isUngated(pathname)) return NextResponse.next();
@@ -71,9 +71,7 @@ function isUnder(pathname: string, prefix: string): boolean {
 }
 
 function isPublic(pathname: string): boolean {
-	if (pathname === LANDING_PATH) return isMarketing();
-
-	return PUBLIC.some((prefix) => isUnder(pathname, prefix));
+	return pathname === LANDING_PATH && isMarketing();
 }
 
 function isUngated(pathname: string): boolean {

--- a/apps/app/test/onboarding-gate.spec.ts
+++ b/apps/app/test/onboarding-gate.spec.ts
@@ -170,6 +170,19 @@ describe("proxy", () => {
 		expect(redirectedTo(await proxy(request("/sign-in")))).toBeNull();
 	});
 
+	it("never aims a redirect at the sign-in page itself", async () => {
+		marketing(undefined);
+		setup({ onboarded: false, configured: false });
+
+		expect(redirectedTo(await proxy(request("/sign-in")))).toBeNull();
+		expect(
+			redirectedTo(await proxy(request("/sign-in", [SESSION_COOKIE]))),
+		).toBeNull();
+		expect(
+			redirectedTo(await proxy(request("/sign-in?method=google"))),
+		).toBeNull();
+	});
+
 	it("reads the flag on every request, and only the literal true turns it on", async () => {
 		marketing("false");
 		expect(redirectedTo(await proxy(request("/")))).toBe("/sign-in");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes redirect loops around sign-in and tightens public route gating. `/sign-in` always passes through, and the landing page is public only when the marketing flag is on.

- **Bug Fixes**
  - Never redirect when the request path is `/sign-in` to prevent loops and keep auth provider query params intact.
  - Added tests to ensure `/sign-in` is never the redirect target for signed-in or signed-out users.

- **Refactors**
  - Removed the `PUBLIC` list; `isPublic` now only allows the landing page when marketing is enabled.
  - Removed `/sign-in` from `UNGATED`; only `/grant-access` and `/eve` remain.

<sup>Written for commit 73875f0cc22852a035a4f832beb3ced6d111decd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

