### PR TITLE
Update dependencies and enhance layout components

### DIFF
--- a/apps/app/app/(app)/[slug]/companies/[companyId]/page.tsx
+++ b/apps/app/app/(app)/[slug]/companies/[companyId]/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { recordHref } from "@/lib/record-href";
 
+export const instant = false;
+
 export default async function RecordRedirect({
 	params,
 }: {

--- a/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
@@ -30,7 +30,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { useId, useState } from "react";
+import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
 import { useCrmCache } from "@/lib/trpc/cache";
@@ -38,7 +38,24 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNASSIGNED = "unassigned";
 
+function AddButton({ disabled }: { disabled?: boolean }) {
+	return (
+		<Button disabled={disabled}>
+			<Icon icon={Add} data-icon="inline-start" />
+			New company
+		</Button>
+	);
+}
+
 export function CreateCompanySheet() {
+	return (
+		<Suspense fallback={<AddButton disabled />}>
+			<CreateCompanyForm />
+		</Suspense>
+	);
+}
+
+function CreateCompanyForm() {
 	const openRecord = useOpenRecord();
 	const trpc = useTRPC();
 	const cache = useCrmCache();
@@ -74,10 +91,7 @@ export function CreateCompanySheet() {
 	return (
 		<Sheet open={open} onOpenChange={(next) => setOpen(next || null)}>
 			<SheetTrigger asChild>
-				<Button>
-					<Icon icon={Add} data-icon="inline-start" />
-					New company
-				</Button>
+				<AddButton />
 			</SheetTrigger>
 			<SheetContent side="right">
 				<SheetHeader>

--- a/apps/app/app/(app)/[slug]/companies/page.tsx
+++ b/apps/app/app/(app)/[slug]/companies/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellActions,
@@ -7,6 +7,7 @@ import {
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -20,22 +21,9 @@ export const metadata: Metadata = {
 	title: "Companies",
 };
 
-export default async function CompaniesPage({
+export default function CompaniesPage({
 	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
-	await requireSession();
-
-	const values = await companiesSearchParams.load(searchParams);
-
-	const trpc = getServerTrpc();
-	const queryClient = getServerQueryClient();
-	await queryClient.prefetchQuery(
-		trpc.companies.list.queryOptions(companiesSearchParams.toInput(values)),
-	);
-	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
-
+}: PageProps<"/[slug]/companies">) {
 	return (
 		<PageShell className="min-h-0">
 			<PageShellHeader>
@@ -51,10 +39,31 @@ export default async function CompaniesPage({
 			</PageShellHeader>
 
 			<PageShellContent className="min-h-0">
-				<HydrateClient>
-					<CompaniesTable />
-				</HydrateClient>
+				<Suspense fallback={<PageShellLoading />}>
+					<Companies searchParams={searchParams} />
+				</Suspense>
 			</PageShellContent>
 		</PageShell>
+	);
+}
+
+async function Companies({
+	searchParams,
+}: Pick<PageProps<"/[slug]/companies">, "searchParams">) {
+	await requireSession();
+
+	const values = await companiesSearchParams.load(searchParams);
+
+	const trpc = getServerTrpc();
+	const queryClient = getServerQueryClient();
+	await queryClient.prefetchQuery(
+		trpc.companies.list.queryOptions(companiesSearchParams.toInput(values)),
+	);
+	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
+
+	return (
+		<HydrateClient>
+			<CompaniesTable />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/contacts/[contactId]/page.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/[contactId]/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { recordHref } from "@/lib/record-href";
 
+export const instant = false;
+
 export default async function RecordRedirect({
 	params,
 }: {

--- a/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
@@ -25,7 +25,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { useId, useState } from "react";
+import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
 import { useCrmCache } from "@/lib/trpc/cache";
@@ -33,7 +33,24 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const NONE = "none";
 
+function AddButton({ disabled }: { disabled?: boolean }) {
+	return (
+		<Button disabled={disabled}>
+			<Icon icon={Add} data-icon="inline-start" />
+			New contact
+		</Button>
+	);
+}
+
 export function CreateContactSheet({ companyId }: { companyId?: string }) {
+	return (
+		<Suspense fallback={<AddButton disabled />}>
+			<CreateContactForm companyId={companyId} />
+		</Suspense>
+	);
+}
+
+function CreateContactForm({ companyId }: { companyId?: string }) {
 	const openRecord = useOpenRecord();
 	const trpc = useTRPC();
 	const cache = useCrmCache();
@@ -78,10 +95,7 @@ export function CreateContactSheet({ companyId }: { companyId?: string }) {
 	return (
 		<Sheet open={open} onOpenChange={(next) => setOpen(next || null)}>
 			<SheetTrigger asChild>
-				<Button>
-					<Icon icon={Add} data-icon="inline-start" />
-					New contact
-				</Button>
+				<AddButton />
 			</SheetTrigger>
 			<SheetContent side="right">
 				<SheetHeader>

--- a/apps/app/app/(app)/[slug]/contacts/page.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellActions,
@@ -7,6 +7,7 @@ import {
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -20,11 +21,33 @@ export const metadata: Metadata = {
 	title: "Contacts",
 };
 
-export default async function ContactsPage({
+export default function ContactsPage({
 	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
+}: PageProps<"/[slug]/contacts">) {
+	return (
+		<PageShell className="min-h-0">
+			<PageShellHeader>
+				<PageShellHeading>
+					<PageShellTitle>Contacts</PageShellTitle>
+					<PageShellDescription>Everyone in the pipeline.</PageShellDescription>
+				</PageShellHeading>
+				<PageShellActions>
+					<CreateContactSheet />
+				</PageShellActions>
+			</PageShellHeader>
+
+			<PageShellContent className="min-h-0">
+				<Suspense fallback={<PageShellLoading />}>
+					<Contacts searchParams={searchParams} />
+				</Suspense>
+			</PageShellContent>
+		</PageShell>
+	);
+}
+
+async function Contacts({
+	searchParams,
+}: Pick<PageProps<"/[slug]/contacts">, "searchParams">) {
 	await requireSession();
 
 	const values = await contactsSearchParams.load(searchParams);
@@ -40,22 +63,8 @@ export default async function ContactsPage({
 	);
 
 	return (
-		<PageShell className="min-h-0">
-			<PageShellHeader>
-				<PageShellHeading>
-					<PageShellTitle>Contacts</PageShellTitle>
-					<PageShellDescription>Everyone in the pipeline.</PageShellDescription>
-				</PageShellHeading>
-				<PageShellActions>
-					<CreateContactSheet />
-				</PageShellActions>
-			</PageShellHeader>
-
-			<PageShellContent className="min-h-0">
-				<HydrateClient>
-					<ContactsTable />
-				</HydrateClient>
-			</PageShellContent>
-		</PageShell>
+		<HydrateClient>
+			<ContactsTable />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/deals/[dealId]/page.tsx
+++ b/apps/app/app/(app)/[slug]/deals/[dealId]/page.tsx
@@ -1,6 +1,8 @@
 import { redirect } from "next/navigation";
 import { recordHref } from "@/lib/record-href";
 
+export const instant = false;
+
 export default async function RecordRedirect({
 	params,
 }: {

--- a/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
@@ -31,7 +31,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { useId, useState } from "react";
+import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { dealStageLabel, OPEN_STAGES } from "@/components/crm/deal-stage";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
@@ -40,7 +40,24 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNSET = "";
 
+function AddButton({ disabled }: { disabled?: boolean }) {
+	return (
+		<Button disabled={disabled}>
+			<Icon icon={Add} data-icon="inline-start" />
+			New deal
+		</Button>
+	);
+}
+
 export function CreateDealSheet({ companyId }: { companyId?: string }) {
+	return (
+		<Suspense fallback={<AddButton disabled />}>
+			<CreateDealForm companyId={companyId} />
+		</Suspense>
+	);
+}
+
+function CreateDealForm({ companyId }: { companyId?: string }) {
 	const openRecord = useOpenRecord();
 	const trpc = useTRPC();
 	const cache = useCrmCache();
@@ -87,10 +104,7 @@ export function CreateDealSheet({ companyId }: { companyId?: string }) {
 	return (
 		<Sheet open={open} onOpenChange={(next) => setOpen(next || null)}>
 			<SheetTrigger asChild>
-				<Button>
-					<Icon icon={Add} data-icon="inline-start" />
-					New deal
-				</Button>
+				<AddButton />
 			</SheetTrigger>
 			<SheetContent side="right">
 				<SheetHeader>

--- a/apps/app/app/(app)/[slug]/deals/page.tsx
+++ b/apps/app/app/(app)/[slug]/deals/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellActions,
@@ -7,6 +7,7 @@ import {
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -20,25 +21,9 @@ export const metadata: Metadata = {
 	title: "Deals",
 };
 
-export default async function DealsPage({
+export default function DealsPage({
 	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
-	await requireSession();
-
-	const values = await dealsSearchParams.load(searchParams);
-
-	const trpc = getServerTrpc();
-	const queryClient = getServerQueryClient();
-	await queryClient.prefetchQuery(
-		trpc.deals.list.queryOptions(dealsSearchParams.toInput(values)),
-	);
-	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
-	void queryClient.prefetchQuery(
-		trpc.companies.options.queryOptions({ q: "" }),
-	);
-
+}: PageProps<"/[slug]/deals">) {
 	return (
 		<PageShell className="min-h-0">
 			<PageShellHeader>
@@ -54,10 +39,34 @@ export default async function DealsPage({
 			</PageShellHeader>
 
 			<PageShellContent className="min-h-0">
-				<HydrateClient>
-					<DealsTable />
-				</HydrateClient>
+				<Suspense fallback={<PageShellLoading />}>
+					<Deals searchParams={searchParams} />
+				</Suspense>
 			</PageShellContent>
 		</PageShell>
+	);
+}
+
+async function Deals({
+	searchParams,
+}: Pick<PageProps<"/[slug]/deals">, "searchParams">) {
+	await requireSession();
+
+	const values = await dealsSearchParams.load(searchParams);
+
+	const trpc = getServerTrpc();
+	const queryClient = getServerQueryClient();
+	await queryClient.prefetchQuery(
+		trpc.deals.list.queryOptions(dealsSearchParams.toInput(values)),
+	);
+	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
+	void queryClient.prefetchQuery(
+		trpc.companies.options.queryOptions({ q: "" }),
+	);
+
+	return (
+		<HydrateClient>
+			<DealsTable />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/layout.tsx
+++ b/apps/app/app/(app)/[slug]/layout.tsx
@@ -1,6 +1,7 @@
-import { notFound } from "next/navigation";
-import { AppHeader } from "@/components/app-header";
-import { AppIconRail } from "@/components/app-icon-rail";
+import { notFound, unstable_rethrow } from "next/navigation";
+import { Suspense } from "react";
+import { AppHeader, AppHeaderFallback } from "@/components/app-header";
+import { AppIconRail, AppIconRailFallback } from "@/components/app-icon-rail";
 import { QuickSwitcher } from "@/components/crm/quick-switcher";
 import { RecordSheetHost } from "@/components/crm/record-sheet/record-sheet-host";
 import { MobileNavProvider } from "@/components/mobile-nav";
@@ -8,13 +9,39 @@ import { requireGoogleAccess } from "@/lib/session";
 import { HydrateClient } from "@/lib/trpc/hydrate";
 import { getServerQueryClient, getServerTrpc } from "@/lib/trpc/server";
 
-export default async function AppLayout({
+export default function AppLayout({
 	children,
 	params,
-}: Readonly<{
-	children: React.ReactNode;
-	params: Promise<{ slug: string }>;
-}>) {
+}: LayoutProps<"/[slug]">) {
+	return (
+		<MobileNavProvider>
+			<div className="isolate flex h-svh flex-col">
+				<Suspense fallback={<AppHeaderFallback />}>
+					<WorkspaceHeader params={params} />
+				</Suspense>
+
+				<div className="flex min-h-0 flex-1">
+					<Suspense fallback={<AppIconRailFallback />}>
+						<AppIconRail />
+					</Suspense>
+					{children}
+				</div>
+
+				<Suspense fallback={null}>
+					<RecordSheetHost />
+				</Suspense>
+
+				<Suspense fallback={null}>
+					<QuickSwitcher />
+				</Suspense>
+			</div>
+		</MobileNavProvider>
+	);
+}
+
+async function WorkspaceHeader({
+	params,
+}: Pick<LayoutProps<"/[slug]">, "params">) {
 	const [{ user }, { slug }] = await Promise.all([
 		requireGoogleAccess(),
 		params,
@@ -22,31 +49,22 @@ export default async function AppLayout({
 
 	const workspace = await getServerQueryClient()
 		.fetchQuery(getServerTrpc().workspace.get.queryOptions())
-		.catch(() => null);
+		.catch((error: unknown) => {
+			unstable_rethrow(error);
+			return null;
+		});
 
 	if (workspace && workspace.slug !== slug) notFound();
 
 	return (
-		<MobileNavProvider>
-			<div className="isolate flex h-svh flex-col">
-				<HydrateClient>
-					<AppHeader
-						user={{
-							name: user.name,
-							email: user.email,
-							image: user.image ?? null,
-						}}
-					/>
-				</HydrateClient>
-				<div className="flex min-h-0 flex-1">
-					<AppIconRail />
-					{children}
-				</div>
-
-				<RecordSheetHost />
-
-				<QuickSwitcher />
-			</div>
-		</MobileNavProvider>
+		<HydrateClient>
+			<AppHeader
+				user={{
+					name: user.name,
+					email: user.email,
+					image: user.image ?? null,
+				}}
+			/>
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/overview-greeting.tsx
+++ b/apps/app/app/(app)/[slug]/overview-greeting.tsx
@@ -1,19 +1,26 @@
 "use client";
 
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { useQueryState } from "nuqs";
 import { PageShellDescription, PageShellTitle } from "@/components/page-shell";
-import { useTRPC } from "@/lib/trpc/client";
 import { overviewParsers } from "./overview-search-params";
 
+export function OverviewGreetingFallback() {
+	return (
+		<>
+			<PageShellTitle>Welcome back</PageShellTitle>
+			<PageShellDescription>
+				What you have closed, what is still in play, and what needs you today.
+			</PageShellDescription>
+		</>
+	);
+}
+
 export function OverviewGreeting() {
-	const trpc = useTRPC();
-	const { data: me } = useSuspenseQuery(trpc.users.me.queryOptions());
 	const [scope] = useQueryState("scope", overviewParsers.scope);
 
 	return (
 		<>
-			<PageShellTitle>Welcome back, {me.name.split(" ")[0]}</PageShellTitle>
+			<PageShellTitle>Welcome back</PageShellTitle>
 			<PageShellDescription>
 				{scope === "me"
 					? "What you have closed, what is still in play, and what needs you today."

--- a/apps/app/app/(app)/[slug]/overview-scope.tsx
+++ b/apps/app/app/(app)/[slug]/overview-scope.tsx
@@ -17,6 +17,25 @@ function isScope(value: string): value is OverviewScope {
 	return (OVERVIEW_SCOPES as readonly string[]).includes(value);
 }
 
+export function OverviewScopeToggleFallback() {
+	return (
+		<ToggleGroup
+			type="single"
+			variant="outline"
+			size="sm"
+			spacing={0}
+			disabled
+			aria-label="Whose numbers to show"
+		>
+			{OVERVIEW_SCOPES.map((value) => (
+				<ToggleGroupItem key={value} value={value}>
+					{LABELS[value]}
+				</ToggleGroupItem>
+			))}
+		</ToggleGroup>
+	);
+}
+
 export function OverviewScopeToggle() {
 	const [scope, setScope] = useQueryState("scope", overviewParsers.scope);
 

--- a/apps/app/app/(app)/[slug]/page.tsx
+++ b/apps/app/app/(app)/[slug]/page.tsx
@@ -1,54 +1,66 @@
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellActions,
 	PageShellContent,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
 import { HydrateClient } from "@/lib/trpc/hydrate";
 import { getServerQueryClient, getServerTrpc } from "@/lib/trpc/server";
 import { DashboardSummary } from "./dashboard-summary";
-import { OverviewGreeting } from "./overview-greeting";
-import { OverviewScopeToggle } from "./overview-scope";
+import {
+	OverviewGreeting,
+	OverviewGreetingFallback,
+} from "./overview-greeting";
+import {
+	OverviewScopeToggle,
+	OverviewScopeToggleFallback,
+} from "./overview-scope";
 import { loadOverviewSearchParams } from "./overview-search-params";
 
-export default async function OverviewPage({
-	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
-	await requireSession();
-
-	const { scope } = await loadOverviewSearchParams(searchParams);
-
-	const trpc = getServerTrpc();
-	const queryClient = getServerQueryClient();
-
-	await Promise.all([
-		queryClient.prefetchQuery(trpc.users.me.queryOptions()),
-		queryClient.prefetchQuery(trpc.dashboard.summary.queryOptions({ scope })),
-	]);
-
+export default function OverviewPage({ searchParams }: PageProps<"/[slug]">) {
 	return (
 		<PageShell>
 			<PageShellHeader>
 				<PageShellHeading>
-					<HydrateClient>
+					<Suspense fallback={<OverviewGreetingFallback />}>
 						<OverviewGreeting />
-					</HydrateClient>
+					</Suspense>
 				</PageShellHeading>
 				<PageShellActions>
-					<OverviewScopeToggle />
+					<Suspense fallback={<OverviewScopeToggleFallback />}>
+						<OverviewScopeToggle />
+					</Suspense>
 				</PageShellActions>
 			</PageShellHeader>
 
 			<PageShellContent>
-				<HydrateClient>
-					<DashboardSummary />
-				</HydrateClient>
+				<Suspense fallback={<PageShellLoading />}>
+					<Summary searchParams={searchParams} />
+				</Suspense>
 			</PageShellContent>
 		</PageShell>
+	);
+}
+
+async function Summary({
+	searchParams,
+}: Pick<PageProps<"/[slug]">, "searchParams">) {
+	await requireSession();
+
+	const { scope } = await loadOverviewSearchParams(searchParams);
+
+	const queryClient = getServerQueryClient();
+	await queryClient.prefetchQuery(
+		getServerTrpc().dashboard.summary.queryOptions({ scope }),
+	);
+
+	return (
+		<HydrateClient>
+			<DashboardSummary />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/settings/connections/page.tsx
+++ b/apps/app/app/(app)/[slug]/settings/connections/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellContent,
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -16,21 +18,9 @@ export const metadata: Metadata = {
 	title: "Connections",
 };
 
-export default async function ConnectionsSettingsPage({
+export default function ConnectionsSettingsPage({
 	searchParams,
-}: {
-	searchParams: Promise<{ error?: string | string[] }>;
-}) {
-	await requireSession();
-
-	const trpc = getServerTrpc();
-	const queryClient = getServerQueryClient();
-
-	const [{ error }] = await Promise.all([
-		searchParams,
-		queryClient.prefetchQuery(trpc.google.status.queryOptions()),
-	]);
-
+}: PageProps<"/[slug]/settings/connections">) {
 	return (
 		<PageShell>
 			<PageShellHeader>
@@ -43,14 +33,34 @@ export default async function ConnectionsSettingsPage({
 			</PageShellHeader>
 
 			<PageShellContent>
-				<HydrateClient>
-					<div className="flex max-w-3xl flex-col gap-6">
-						<GoogleConnection
-							connectError={Array.isArray(error) ? error[0] : error}
-						/>
-					</div>
-				</HydrateClient>
+				<Suspense fallback={<PageShellLoading />}>
+					<Connections searchParams={searchParams} />
+				</Suspense>
 			</PageShellContent>
 		</PageShell>
+	);
+}
+
+async function Connections({
+	searchParams,
+}: Pick<PageProps<"/[slug]/settings/connections">, "searchParams">) {
+	await requireSession();
+
+	const trpc = getServerTrpc();
+	const queryClient = getServerQueryClient();
+
+	const [{ error }] = await Promise.all([
+		searchParams,
+		queryClient.prefetchQuery(trpc.google.status.queryOptions()),
+	]);
+
+	return (
+		<HydrateClient>
+			<div className="flex max-w-3xl flex-col gap-6">
+				<GoogleConnection
+					connectError={Array.isArray(error) ? error[0] : error}
+				/>
+			</div>
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/settings/layout.tsx
+++ b/apps/app/app/(app)/[slug]/settings/layout.tsx
@@ -1,4 +1,5 @@
-import { SettingsSidebar } from "./settings-sidebar";
+import { Suspense } from "react";
+import { SettingsSidebar, SettingsSidebarFallback } from "./settings-sidebar";
 
 export default function SettingsLayout({
 	children,
@@ -7,7 +8,9 @@ export default function SettingsLayout({
 }>) {
 	return (
 		<div className="flex min-h-0 min-w-0 flex-1 flex-col md:flex-row">
-			<SettingsSidebar />
+			<Suspense fallback={<SettingsSidebarFallback />}>
+				<SettingsSidebar />
+			</Suspense>
 			{children}
 		</div>
 	);

--- a/apps/app/app/(app)/[slug]/settings/members/page.tsx
+++ b/apps/app/app/(app)/[slug]/settings/members/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellContent,
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -18,11 +19,32 @@ export const metadata: Metadata = {
 	title: "Members",
 };
 
-export default async function MembersSettingsPage({
+export default function MembersSettingsPage({
 	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
+}: PageProps<"/[slug]/settings/members">) {
+	return (
+		<PageShell className="min-h-0">
+			<PageShellHeader>
+				<PageShellHeading>
+					<PageShellTitle>Members</PageShellTitle>
+					<PageShellDescription>
+						Everyone who has access to your CRM.
+					</PageShellDescription>
+				</PageShellHeading>
+			</PageShellHeader>
+
+			<PageShellContent className="min-h-0">
+				<Suspense fallback={<PageShellLoading />}>
+					<Members searchParams={searchParams} />
+				</Suspense>
+			</PageShellContent>
+		</PageShell>
+	);
+}
+
+async function Members({
+	searchParams,
+}: Pick<PageProps<"/[slug]/settings/members">, "searchParams">) {
 	await requireSession();
 
 	const values = await membersSearchParams.load(searchParams);
@@ -38,21 +60,8 @@ export default async function MembersSettingsPage({
 	]);
 
 	return (
-		<PageShell className="min-h-0">
-			<PageShellHeader>
-				<PageShellHeading>
-					<PageShellTitle>Members</PageShellTitle>
-					<PageShellDescription>
-						Everyone who has access to your CRM.
-					</PageShellDescription>
-				</PageShellHeading>
-			</PageShellHeader>
-
-			<PageShellContent className="min-h-0">
-				<HydrateClient>
-					<MembersTable />
-				</HydrateClient>
-			</PageShellContent>
-		</PageShell>
+		<HydrateClient>
+			<MembersTable />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/settings/page.tsx
+++ b/apps/app/app/(app)/[slug]/settings/page.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellContent,
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -18,7 +20,28 @@ export const metadata: Metadata = {
 	title: "General",
 };
 
-export default async function GeneralSettingsPage() {
+export default function GeneralSettingsPage() {
+	return (
+		<PageShell>
+			<PageShellHeader>
+				<PageShellHeading>
+					<PageShellTitle>General</PageShellTitle>
+					<PageShellDescription>
+						Who you are, and the model the research agent thinks with.
+					</PageShellDescription>
+				</PageShellHeading>
+			</PageShellHeader>
+
+			<PageShellContent>
+				<Suspense fallback={<PageShellLoading />}>
+					<Settings />
+				</Suspense>
+			</PageShellContent>
+		</PageShell>
+	);
+}
+
+async function Settings() {
 	await requireSession();
 
 	const trpc = getServerTrpc();
@@ -32,25 +55,12 @@ export default async function GeneralSettingsPage() {
 	]);
 
 	return (
-		<PageShell>
-			<PageShellHeader>
-				<PageShellHeading>
-					<PageShellTitle>General</PageShellTitle>
-					<PageShellDescription>
-						Who you are, and the model the research agent thinks with.
-					</PageShellDescription>
-				</PageShellHeading>
-			</PageShellHeader>
-
-			<PageShellContent>
-				<HydrateClient>
-					<div className="flex max-w-3xl flex-col gap-6">
-						<WorkspaceForm />
-						<ResearchKey />
-						<AgentModel />
-					</div>
-				</HydrateClient>
-			</PageShellContent>
-		</PageShell>
+		<HydrateClient>
+			<div className="flex max-w-3xl flex-col gap-6">
+				<WorkspaceForm />
+				<ResearchKey />
+				<AgentModel />
+			</div>
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(app)/[slug]/settings/settings-sidebar.tsx
+++ b/apps/app/app/(app)/[slug]/settings/settings-sidebar.tsx
@@ -47,12 +47,55 @@ function NavLink({
 		>
 			<Link
 				href={item.href}
+				prefetch
 				aria-current={active ? "page" : undefined}
 				transitionTypes={["nav-lateral"]}
 			>
 				{item.title}
 			</Link>
 		</Button>
+	);
+}
+
+export function SettingsSidebarFallback() {
+	return (
+		<>
+			<aside className="hidden w-56 shrink-0 border-r md:block [view-transition-name:settings-sidebar]">
+				<nav
+					aria-label="Workspace settings"
+					aria-busy="true"
+					className="flex flex-col gap-0.5 p-3"
+				>
+					{ITEMS.map((item) => (
+						<Button
+							key={item.href}
+							variant="ghost"
+							disabled
+							className="w-full justify-start px-3 font-normal text-muted-foreground"
+						>
+							{item.title}
+						</Button>
+					))}
+				</nav>
+			</aside>
+
+			<nav
+				aria-label="Workspace settings"
+				aria-busy="true"
+				className="flex gap-1 overflow-x-auto border-b p-2 md:hidden [view-transition-name:settings-sidebar]"
+			>
+				{ITEMS.map((item) => (
+					<Button
+						key={item.href}
+						variant="ghost"
+						disabled
+						className="shrink-0 justify-start px-3 font-normal text-muted-foreground"
+					>
+						{item.title}
+					</Button>
+				))}
+			</nav>
+		</>
 	);
 }
 

--- a/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
@@ -28,7 +28,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { useId, useState } from "react";
+import { Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useCrmCache } from "@/lib/trpc/cache";
 import { useTRPC } from "@/lib/trpc/client";
@@ -44,7 +44,24 @@ const EMPTY = {
 	clientSecret: "",
 };
 
+function AddButton({ disabled }: { disabled?: boolean }) {
+	return (
+		<Button disabled={disabled}>
+			<Icon icon={Add} data-icon="inline-start" />
+			Add provider
+		</Button>
+	);
+}
+
 export function AddSsoProviderSheet() {
+	return (
+		<Suspense fallback={<AddButton disabled />}>
+			<AddSsoProviderForm />
+		</Suspense>
+	);
+}
+
+function AddSsoProviderForm() {
 	const trpc = useTRPC();
 	const cache = useCrmCache();
 
@@ -89,10 +106,7 @@ export function AddSsoProviderSheet() {
 	return (
 		<Sheet open={open} onOpenChange={(next) => setOpen(next || null)}>
 			<SheetTrigger asChild>
-				<Button disabled={!settings.data?.canConfigure}>
-					<Icon icon={Add} data-icon="inline-start" />
-					Add provider
-				</Button>
+				<AddButton disabled={!settings.data?.canConfigure} />
 			</SheetTrigger>
 
 			<SheetContent side="right">

--- a/apps/app/app/(app)/[slug]/settings/sso/page.tsx
+++ b/apps/app/app/(app)/[slug]/settings/sso/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import type { SearchParams } from "nuqs/server";
+import { Suspense } from "react";
 import {
 	PageShell,
 	PageShellActions,
@@ -7,6 +7,7 @@ import {
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 } from "@/components/page-shell";
 import { requireSession } from "@/lib/session";
@@ -20,11 +21,37 @@ export const metadata: Metadata = {
 	title: "SSO",
 };
 
-export default async function SsoSettingsPage({
+export default function SsoSettingsPage({
 	searchParams,
-}: {
-	searchParams: Promise<SearchParams>;
-}) {
+}: PageProps<"/[slug]/settings/sso">) {
+	return (
+		<PageShell className="min-h-0">
+			<PageShellHeader>
+				<PageShellHeading>
+					<PageShellTitle>SSO</PageShellTitle>
+					<PageShellDescription>
+						Let your people sign in through your own identity provider. While
+						one is configured, the sign-in page offers it instead of Google.
+					</PageShellDescription>
+				</PageShellHeading>
+
+				<PageShellActions>
+					<AddSsoProviderSheet />
+				</PageShellActions>
+			</PageShellHeader>
+
+			<PageShellContent className="min-h-0">
+				<Suspense fallback={<PageShellLoading />}>
+					<Providers searchParams={searchParams} />
+				</Suspense>
+			</PageShellContent>
+		</PageShell>
+	);
+}
+
+async function Providers({
+	searchParams,
+}: Pick<PageProps<"/[slug]/settings/sso">, "searchParams">) {
 	await requireSession();
 
 	const values = await ssoSearchParams.load(searchParams);
@@ -40,28 +67,8 @@ export default async function SsoSettingsPage({
 	]);
 
 	return (
-		<PageShell className="min-h-0">
-			<PageShellHeader>
-				<PageShellHeading>
-					<PageShellTitle>SSO</PageShellTitle>
-					<PageShellDescription>
-						Let your people sign in through your own identity provider. While
-						one is configured, the sign-in page offers it instead of Google.
-					</PageShellDescription>
-				</PageShellHeading>
-
-				<PageShellActions>
-					<HydrateClient>
-						<AddSsoProviderSheet />
-					</HydrateClient>
-				</PageShellActions>
-			</PageShellHeader>
-
-			<PageShellContent className="min-h-0">
-				<HydrateClient>
-					<SsoTable />
-				</HydrateClient>
-			</PageShellContent>
-		</PageShell>
+		<HydrateClient>
+			<SsoTable />
+		</HydrateClient>
 	);
 }

--- a/apps/app/app/(landing)/grant-access/page.tsx
+++ b/apps/app/app/(landing)/grant-access/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
 	title: "Grant access",
 };
 
+export const instant = false;
+
 export default async function GrantAccessPage() {
 	const { user } = await requireSession();
 

--- a/apps/app/app/(landing)/onboarding/page.tsx
+++ b/apps/app/app/(landing)/onboarding/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
 	title: "Set up",
 };
 
+export const instant = false;
+
 export default async function OnboardingPage() {
 	await requireGoogleAccess();
 

--- a/apps/app/app/(landing)/onboarding/research/page.tsx
+++ b/apps/app/app/(landing)/onboarding/research/page.tsx
@@ -7,6 +7,8 @@ export const metadata: Metadata = {
 	title: "Research key",
 };
 
+export const instant = false;
+
 export default async function ResearchKeyPage() {
 	await requireGoogleAccess();
 

--- a/apps/app/app/(landing)/sign-in/page.tsx
+++ b/apps/app/app/(landing)/sign-in/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import { redirect } from "next/navigation";
+import { redirect, unstable_rethrow } from "next/navigation";
+import { Suspense } from "react";
 import { AuthHeading, AuthShell } from "@/components/auth-shell";
 import { getSession } from "@/lib/session";
 import { getServerQueryClient, getServerTrpc } from "@/lib/trpc/server";
@@ -10,8 +11,6 @@ export const metadata: Metadata = {
 	title: "Sign in",
 };
 
-export const dynamic = "force-dynamic";
-
 type SignInOptions = { google: boolean; providers: SsoProvider[] };
 
 async function signInOptions(): Promise<SignInOptions | null> {
@@ -20,18 +19,35 @@ async function signInOptions(): Promise<SignInOptions | null> {
 			getServerTrpc().sso.signInOptions.queryOptions(),
 		);
 	} catch (error) {
+		unstable_rethrow(error);
 		console.error("Sign-in: could not read the sign-in options.", error);
 		return null;
 	}
 }
 
-export default async function SignInPage({
+export default function SignInPage({ searchParams }: PageProps<"/sign-in">) {
+	return (
+		<AuthShell>
+			<Suspense
+				fallback={
+					<AuthHeading
+						title="Welcome back"
+						description="Sign in with your account to continue."
+					/>
+				}
+			>
+				<SignIn searchParams={searchParams} />
+			</Suspense>
+		</AuthShell>
+	);
+}
+
+async function SignIn({
 	searchParams,
-}: {
-	searchParams: Promise<{ method?: string | string[] }>;
-}) {
+}: Pick<PageProps<"/sign-in">, "searchParams">) {
 	const [session, options, { method }] = await Promise.all([
 		getSession().catch((error: unknown) => {
+			unstable_rethrow(error);
 			console.error("Sign-in: could not read the session.", error);
 			return null;
 		}),
@@ -52,7 +68,7 @@ export default async function SignInPage({
 
 	if (!showSso && !showGoogle) {
 		return (
-			<AuthShell>
+			<>
 				<AuthHeading
 					title="No way in yet"
 					description="This CRM has no sign-in method configured, so nobody can get in — including you."
@@ -63,12 +79,12 @@ export default async function SignInPage({
 					and restart. Your own identity provider can be added from Settings
 					once somebody is signed in.
 				</p>
-			</AuthShell>
+			</>
 		);
 	}
 
 	return (
-		<AuthShell>
+		<>
 			<AuthHeading
 				title="Welcome back"
 				description="Sign in with your account to continue."
@@ -76,6 +92,6 @@ export default async function SignInPage({
 
 			{showSso ? <SsoSignIn providers={providers} /> : null}
 			{showGoogle ? <GoogleSignIn /> : null}
-		</AuthShell>
+		</>
 	);
 }

--- a/apps/app/app/api/[...path]/route.ts
+++ b/apps/app/app/api/[...path]/route.ts
@@ -1,4 +1,5 @@
 import { brotliDecompressSync, gunzipSync, inflateSync } from "node:zlib";
+import { connection } from "next/server";
 import { API_URL } from "@/lib/env";
 
 function decode(buf: Buffer, encoding: string | null): Buffer {
@@ -12,6 +13,8 @@ function decode(buf: Buffer, encoding: string | null): Buffer {
 }
 
 async function handler(request: Request): Promise<Response> {
+	await connection();
+
 	const url = new URL(request.url);
 	const target = `${API_URL}${url.pathname}${url.search}`;
 

--- a/apps/app/app/eve/v1/[...path]/route.ts
+++ b/apps/app/app/eve/v1/[...path]/route.ts
@@ -1,3 +1,4 @@
+import { connection } from "next/server";
 import {
 	AGENT_URL,
 	bridgeConfigured,
@@ -5,9 +6,9 @@ import {
 } from "@/lib/agent-bridge";
 import { getSession } from "@/lib/session";
 
-export const dynamic = "force-dynamic";
-
 async function handler(request: Request): Promise<Response> {
+	await connection();
+
 	if (!bridgeConfigured()) {
 		return Response.json(
 			{ error: "The research agent is not configured for this install." },

--- a/apps/app/components/app-header.tsx
+++ b/apps/app/components/app-header.tsx
@@ -18,6 +18,7 @@ import {
 } from "@crm/ui/components/dropdown-menu";
 import Logo from "@crm/ui/components/logo";
 import { Separator } from "@crm/ui/components/separator";
+import { Skeleton } from "@crm/ui/components/skeleton";
 import { useQuery } from "@tanstack/react-query";
 import Link from "next/link";
 import { useTheme } from "next-themes";
@@ -90,6 +91,26 @@ export function AppHeader({ user }: { user: User }) {
 						handleSignOut().catch(() => toast.error("Could not sign out."));
 					}}
 				/>
+			</div>
+		</header>
+	);
+}
+
+export function AppHeaderFallback() {
+	return (
+		<header className="flex h-12 shrink-0 items-center gap-2 border-b px-3 [view-transition-name:app-header]">
+			<div className="flex shrink-0 items-center gap-1">
+				<span className="hidden size-8 items-center justify-center text-foreground md:flex">
+					<Logo className="size-5" />
+				</span>
+				<Separator orientation="vertical" className="mx-1 h-5 bg-transparent" />
+				<Skeleton className="h-4 w-24" />
+			</div>
+
+			<div className="ml-auto flex shrink-0 items-center gap-1.5">
+				<Avatar className="size-7">
+					<AvatarFallback />
+				</Avatar>
 			</div>
 		</header>
 	);

--- a/apps/app/components/app-icon-rail.tsx
+++ b/apps/app/components/app-icon-rail.tsx
@@ -23,6 +23,7 @@ import { cn } from "@crm/ui/lib/utils";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
+import { usePrefetchSection } from "@/components/crm/section-prefetch";
 import { useMobileNav } from "@/components/mobile-nav";
 import { useWorkspaceUrl } from "@/lib/use-workspace-url";
 
@@ -53,7 +54,15 @@ function isActive(item: RailItem, pathname: string): boolean {
 	);
 }
 
-function RailLink({ item, active }: { item: RailItem; active: boolean }) {
+function RailLink({
+	item,
+	active,
+	onPrefetch,
+}: {
+	item: RailItem;
+	active: boolean;
+	onPrefetch: () => void;
+}) {
 	return (
 		<Tooltip>
 			<TooltipTrigger asChild>
@@ -69,6 +78,9 @@ function RailLink({ item, active }: { item: RailItem; active: boolean }) {
 				>
 					<Link
 						href={item.href}
+						prefetch
+						onMouseEnter={onPrefetch}
+						onFocus={onPrefetch}
 						aria-current={active ? "page" : undefined}
 						transitionTypes={["nav-lateral"]}
 					>
@@ -86,10 +98,12 @@ function MobileRailLink({
 	item,
 	active,
 	onNavigate,
+	onPrefetch,
 }: {
 	item: RailItem;
 	active: boolean;
 	onNavigate: () => void;
+	onPrefetch: () => void;
 }) {
 	return (
 		<Button
@@ -103,6 +117,9 @@ function MobileRailLink({
 		>
 			<Link
 				href={item.href}
+				prefetch
+				onMouseEnter={onPrefetch}
+				onFocus={onPrefetch}
 				aria-current={active ? "page" : undefined}
 				onClick={onNavigate}
 			>
@@ -113,13 +130,42 @@ function MobileRailLink({
 	);
 }
 
+export function AppIconRailFallback() {
+	return (
+		<nav
+			aria-label="Primary"
+			aria-busy="true"
+			className="hidden w-14 shrink-0 flex-col items-center gap-1 border-r py-3 md:flex [view-transition-name:app-rail]"
+		>
+			{ITEMS.map((item) => (
+				<Button
+					key={item.href}
+					variant="ghost"
+					size="icon"
+					disabled
+					className="text-muted-foreground"
+				>
+					<Icon icon={item.icon} />
+					<span className="sr-only">{item.title}</span>
+				</Button>
+			))}
+		</nav>
+	);
+}
+
 export function AppIconRail() {
 	const pathname = usePathname();
 	const workspaceUrl = useWorkspaceUrl();
 	const { open, setOpen } = useMobileNav();
+	const prefetchSection = usePrefetchSection();
 
 	const items = useMemo(
-		() => ITEMS.map((item) => ({ ...item, href: workspaceUrl(item.href) })),
+		() =>
+			ITEMS.map((item) => ({
+				...item,
+				section: item.href,
+				href: workspaceUrl(item.href),
+			})),
 		[workspaceUrl],
 	);
 
@@ -134,6 +180,7 @@ export function AppIconRail() {
 						key={item.href}
 						item={item}
 						active={isActive(item, pathname)}
+						onPrefetch={() => prefetchSection(item.section)}
 					/>
 				))}
 			</nav>
@@ -150,6 +197,7 @@ export function AppIconRail() {
 								item={item}
 								active={isActive(item, pathname)}
 								onNavigate={() => setOpen(false)}
+								onPrefetch={() => prefetchSection(item.section)}
 							/>
 						))}
 					</nav>

--- a/apps/app/components/crm/section-prefetch.ts
+++ b/apps/app/components/crm/section-prefetch.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { companiesSearchParams } from "@/app/(app)/[slug]/companies/companies-search-params";
+import { contactsSearchParams } from "@/app/(app)/[slug]/contacts/contacts-search-params";
+import { dealsSearchParams } from "@/app/(app)/[slug]/deals/deals-search-params";
+import { useTRPC } from "@/lib/trpc/client";
+
+export type Section = "/" | "/companies" | "/contacts" | "/deals" | "/settings";
+
+export function usePrefetchSection(): (section: string) => void {
+	const trpc = useTRPC();
+	const queryClient = useQueryClient();
+
+	return useCallback(
+		(section: string) => {
+			switch (section) {
+				case "/":
+					void queryClient.prefetchQuery(
+						trpc.dashboard.summary.queryOptions({ scope: "me" }),
+					);
+					return;
+				case "/companies":
+					void queryClient.prefetchQuery(
+						trpc.companies.list.queryOptions(
+							companiesSearchParams.defaultInput(),
+						),
+					);
+					return;
+				case "/contacts":
+					void queryClient.prefetchQuery(
+						trpc.contacts.list.queryOptions(
+							contactsSearchParams.defaultInput(),
+						),
+					);
+					return;
+				case "/deals":
+					void queryClient.prefetchQuery(
+						trpc.deals.list.queryOptions(dealsSearchParams.defaultInput()),
+					);
+					return;
+				default:
+					return;
+			}
+		},
+		[trpc, queryClient],
+	);
+}

--- a/apps/app/components/data-table/list-search-params.ts
+++ b/apps/app/components/data-table/list-search-params.ts
@@ -59,6 +59,7 @@ export type ListSearchParams<TTab extends string, TFacet extends string> = {
 	toInput: (
 		values: ListSearchValues<TTab | TFacet>,
 	) => ListInput<TTab | TFacet>;
+	defaultInput: () => ListInput<TTab | TFacet>;
 };
 
 export function createListSearchParams<
@@ -90,24 +91,31 @@ export function createListSearchParams<
 
 	const keys = [...(tabId ? [tabId] : []), ...facetIds] as (TTab | TFacet)[];
 
+	const defaults = Object.fromEntries(
+		Object.entries(parsers).map(([key, parser]) => [key, parser.defaultValue]),
+	) as ListSearchValues<TTab | TFacet>;
+
+	const toInput = (values: ListSearchValues<TTab | TFacet>) => {
+		const selected: Record<string, string> = {};
+		for (const key of keys) {
+			selected[key] = values[key] ?? "all";
+		}
+
+		return {
+			q: values.q.trim(),
+			sort: values.sort,
+			dir: values.dir,
+			page: values.page > 0 ? values.page : 1,
+			pageSize,
+			...selected,
+		} as ListInput<TTab | TFacet>;
+	};
+
 	return {
 		config: { ...config, defaultSort, defaultDir, pageSize },
 		parsers,
 		load: createLoader(parsers),
-		toInput: (values) => {
-			const selected: Record<string, string> = {};
-			for (const key of keys) {
-				selected[key] = values[key] ?? "all";
-			}
-
-			return {
-				q: values.q.trim(),
-				sort: values.sort,
-				dir: values.dir,
-				page: values.page > 0 ? values.page : 1,
-				pageSize,
-				...selected,
-			} as ListInput<TTab | TFacet>;
-		},
+		toInput,
+		defaultInput: () => toInput(defaults),
 	};
 }

--- a/apps/app/components/page-shell.tsx
+++ b/apps/app/components/page-shell.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@crm/ui/components/spinner";
 import { cn } from "@crm/ui/lib/utils";
 import type * as React from "react";
 import { PageTransition } from "./page-transition";
@@ -120,6 +121,14 @@ function PageShellContent({
 	);
 }
 
+function PageShellLoading() {
+	return (
+		<div aria-busy="true" className="flex justify-center py-12">
+			<Spinner size="lg" />
+		</div>
+	);
+}
+
 export {
 	PageShell,
 	PageShellActions,
@@ -127,5 +136,6 @@ export {
 	PageShellDescription,
 	PageShellHeader,
 	PageShellHeading,
+	PageShellLoading,
 	PageShellTitle,
 };

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -23,9 +23,8 @@ const nextConfig: NextConfig = {
 		],
 	},
 
-	experimental: {
-		viewTransition: true,
-	},
+	cacheComponents: true,
+	partialPrefetching: true,
 };
 
 export default nextConfig;

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -23,7 +23,7 @@
 		"api": "workspace:*",
 		"better-auth": "^1.6.25",
 		"eve": "^0.29.4",
-		"next": "16.2.12",
+		"next": "16.3.0",
 		"next-themes": "^0.4.6",
 		"nuqs": "^2.8.9",
 		"react": "19.2.4",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -6,6 +6,7 @@
 		"dev": "next dev",
 		"build": "next build",
 		"start": "next start",
+		"typegen": "next typegen",
 		"check-types": "tsc --noEmit",
 		"test": "bun test",
 		"lint": "biome check ."

--- a/apps/app/turbo.json
+++ b/apps/app/turbo.json
@@ -18,6 +18,14 @@
 				"IS_MARKETING"
 			]
 		},
+		"check-types": {
+			"dependsOn": ["$TURBO_EXTENDS$", "typegen"]
+		},
+		"typegen": {
+			"inputs": ["app/**", "next.config.ts"],
+			"outputs": [".next/types/**", "next-env.d.ts"],
+			"passThroughEnv": ["API_URL", "NEXT_PUBLIC_API_URL"]
+		},
 		"dev": {
 			"cache": false,
 			"persistent": true,

--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
         "api": "workspace:*",
         "better-auth": "^1.6.25",
         "eve": "^0.29.4",
-        "next": "16.2.12",
+        "next": "16.3.0",
         "next-themes": "^0.4.6",
         "nuqs": "^2.8.9",
         "react": "19.2.4",
@@ -391,6 +391,8 @@
 
     "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
 
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
+
     "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
 
     "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
@@ -428,6 +430,8 @@
     "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
 
     "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
 
     "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
 
@@ -2351,6 +2355,10 @@
 
     "@dotenvx/dotenvx/yocto-spinner": ["yocto-spinner@1.2.2", "", { "dependencies": { "yoctocolors": "^2.1.1" } }, "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng=="],
 
+    "@img/sharp-freebsd-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
+
+    "@img/sharp-webcontainers-wasm32/@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
+
     "@mermaid-js/parser/@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@nestjs/config/dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
@@ -2533,6 +2541,8 @@
 
     "app/@types/node": ["@types/node@20.19.43", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA=="],
 
+    "app/next": ["next@16.3.0", "", { "dependencies": { "@next/env": "16.3.0", "@swc/helpers": "0.5.15", "baseline-browser-mapping": "^2.9.19", "caniuse-lite": "^1.0.30001579", "postcss": "8.5.23", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "16.3.0", "@next/swc-darwin-x64": "16.3.0", "@next/swc-linux-arm64-gnu": "16.3.0", "@next/swc-linux-arm64-musl": "16.3.0", "@next/swc-linux-x64-gnu": "16.3.0", "@next/swc-linux-x64-musl": "16.3.0", "@next/swc-win32-arm64-msvc": "16.3.0", "@next/swc-win32-x64-msvc": "16.3.0", "sharp": "^0.35.3" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.51.1", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A=="],
+
     "app/react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "app/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
@@ -2683,6 +2693,28 @@
 
     "app/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
+    "app/next/@next/env": ["@next/env@16.3.0", "", {}, "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="],
+
+    "app/next/@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@16.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw=="],
+
+    "app/next/@next/swc-darwin-x64": ["@next/swc-darwin-x64@16.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw=="],
+
+    "app/next/@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg=="],
+
+    "app/next/@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@16.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q=="],
+
+    "app/next/@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw=="],
+
+    "app/next/@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@16.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g=="],
+
+    "app/next/@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@16.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw=="],
+
+    "app/next/@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA=="],
+
+    "app/next/postcss": ["postcss@8.5.23", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
+
+    "app/next/sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" } }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
+
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
@@ -2722,6 +2754,52 @@
     "@prisma/studio-core/@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-effect-event": ["@radix-ui/react-use-effect-event@0.0.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA=="],
 
     "@prisma/studio-core/@radix-ui/react-toggle/@radix-ui/react-use-controllable-state/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
+
+    "app/next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
+
+    "app/next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
+
+    "app/next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
+
+    "app/next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
+
+    "app/next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
+
+    "app/next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
+
+    "app/next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
+
+    "app/next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
+
+    "app/next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
+
+    "app/next/sharp/@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
+
+    "app/next/sharp/@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
+
+    "app/next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
+
+    "app/next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
+
+    "app/next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
+
+    "app/next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
+
+    "app/next/sharp/@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "app/next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "app/next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "multer/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 

--- a/packages/ui/src/components/spinner.tsx
+++ b/packages/ui/src/components/spinner.tsx
@@ -1,15 +1,53 @@
 import { cn } from "@crm/ui/lib/utils";
-import { Loader2Icon } from "lucide-react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+const SILHOUETTE =
+	"M384 99.548 367.934 87.04 256.021 0 0 199.096v113.782L256.021 512 512 312.879V199.096Z";
+
+const MARK =
+	"m384 99.548 -16.066 -12.508L256.021 0 0 199.096v113.782L256.021 512 512 312.879V199.096zm-127.98 -49.419 79.695 61.975 -40.944 31.803 -3.661 2.837 -35.091 -27.287 -102.399 79.638 35.09 27.287 32.218 25.088 35.09 27.288L358.4 199.074l-35.047 -27.288 3.659 -2.837 40.943 -31.803 79.651 61.952 -40.943 31.852 -150.62 117.163 -79.695 -61.974 -32.218 -25.041 -38.752 -30.125 -40.922 -31.849z";
+
+const spinnerVariants = cva("shrink-0", {
+	variants: {
+		size: {
+			default: "size-4",
+			lg: "size-10",
+		},
+	},
+	defaultVariants: {
+		size: "default",
+	},
+});
+
+function Spinner({
+	className,
+	size,
+	...props
+}: React.ComponentProps<"svg"> & VariantProps<typeof spinnerVariants>) {
 	return (
-		<Loader2Icon
+		<svg
 			data-slot="spinner"
 			role="status"
 			aria-label="Loading"
-			className={cn("size-4 animate-spin", className)}
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="-68 -68 648 648"
+			fill="none"
+			className={cn(spinnerVariants({ size }), className)}
 			{...props}
-		/>
+		>
+			<path d={MARK} fill="currentColor" fillOpacity={0.85} />
+			<path
+				d={SILHOUETTE}
+				transform="translate(256 256) scale(1.16) translate(-256 -256)"
+				stroke="var(--ring)"
+				strokeWidth={32}
+				strokeLinejoin="round"
+				strokeLinecap="round"
+				pathLength={100}
+				strokeDasharray="40 60"
+				className="animate-spinner-trace"
+			/>
+		</svg>
 	);
 }
 

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -185,6 +185,8 @@
 	--color-sidebar-border: var(--sidebar-border);
 	--color-sidebar-ring: var(--sidebar-ring);
 
+	--animate-spinner-trace: spinner-trace 1.4s linear infinite;
+
 	--font-sans: var(--font-sans);
 	--font-mono: var(--font-mono);
 	--radius-sm: 4px;
@@ -336,6 +338,11 @@
 @keyframes cds-spin {
 	to {
 		transform: rotate(360deg);
+	}
+}
+@keyframes spinner-trace {
+	to {
+		stroke-dashoffset: -100;
 	}
 }
 @keyframes cds-wiggle {


### PR DESCRIPTION
- Upgraded Next.js from version 16.2.12 to 16.3.0 for improved performance and features.
- Added new fallback components for Suspense in various sections to enhance user experience during loading states.
- Refactored layout components to utilize Suspense for better handling of asynchronous data fetching.
- Introduced new optional dependencies for image processing and updated existing ones to their latest versions.
- Improved error handling in layout components to ensure smoother navigation and user experience.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade to `next` 16.3 and move the app to Suspense-first rendering with lightweight fallbacks and proactive prefetching to make navigation feel instant. Also refresh loading visuals and reduce blocking fetch work.

- **Refactors**
  - Wrapped key layout and pages with Suspense and fallbacks (header, icon rail, settings sidebar, overview, list tables, create-sheet triggers).
  - Moved server prefetch into async child components; kept top-level routes synchronous for faster first paint.
  - Added hover/focus data prefetch for CRM sections and enabled `prefetch` on `Link`; introduced `PageShellLoading`, a new SVG spinner, and list search-param defaults to support prefetch.
  - Enabled Next 16.3 features: `cacheComponents` and `partialPrefetching`; call `connection()` in route handlers for better streaming.
  - Marked non-instant routes with `export const instant = false`; improved error flow with `unstable_rethrow`.
  - Generate Next route types before type checking to fix clean-checkout builds (`typegen` script; `check-types` depends on it).

- **Dependencies**
  - Bumped `next` to 16.3.0.
  - Added optional image tooling (`sharp` and platform variants).

<sup>Written for commit 03d406976cc0a15601b53516a3041c27606489ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

