### PR TITLE
fix: forward SheetTrigger props through AddButton in create sheets

### DIFF
--- a/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
@@ -30,7 +30,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { Suspense, useId, useState } from "react";
+import { type ComponentProps, Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
 import { useCrmCache } from "@/lib/trpc/cache";
@@ -38,9 +38,9 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNASSIGNED = "unassigned";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+function AddButton(props: ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New company
 		</Button>

--- a/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
@@ -25,7 +25,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { Suspense, useId, useState } from "react";
+import { type ComponentProps, Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
 import { useCrmCache } from "@/lib/trpc/cache";
@@ -33,9 +33,9 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const NONE = "none";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+function AddButton(props: ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New contact
 		</Button>

--- a/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
@@ -32,7 +32,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { Suspense, useId, useState } from "react";
+import { type ComponentProps, Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { dealStageLabel, OPEN_STAGES } from "@/components/crm/deal-stage";
 import { useOpenRecord } from "@/components/crm/record-sheet/record-stack";
@@ -41,9 +41,9 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNSET = "";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+function AddButton(props: ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New deal
 		</Button>

--- a/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
@@ -28,7 +28,7 @@ import {
 import { Spinner } from "@crm/ui/components/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { parseAsBoolean, useQueryState } from "nuqs";
-import { Suspense, useId, useState } from "react";
+import { type ComponentProps, Suspense, useId, useState } from "react";
 import { toast } from "sonner";
 import { useCrmCache } from "@/lib/trpc/cache";
 import { useTRPC } from "@/lib/trpc/client";
@@ -44,9 +44,9 @@ const EMPTY = {
 	clientSecret: "",
 };
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+function AddButton(props: ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			Add provider
 		</Button>


### PR DESCRIPTION
## Problem

Clicking **New company**, **New contact**, **New deal**, or **Add provider** (Settings → SSO) does nothing — no sheet opens, no URL change, no console error.

`SheetTrigger asChild` injects `onClick`, aria and data attributes into its child element, but the `AddButton` wrapper in each of the four create sheets only accepted a `disabled` prop and dropped everything else. The trigger's click handler never reached the DOM button, so the sheet's `open` query state was never set.

## Fix

Type `AddButton` as `ComponentProps<typeof Button>` and spread the props through. The `disabled` used by the Suspense fallback still works via the spread.

Reproduced and verified on a self-hosted production build (`next start`) with Playwright: before the patch a click left the URL unchanged and no dialog appeared; after it, `?new=true` is set and the sheet opens.

4 files, same one-line pattern in each:
- `apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx`
- `apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx`
- `apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx`
- `apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx`

`tsc --noEmit` and `biome check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes create-sheet buttons that didn’t open by forwarding `SheetTrigger` props through `AddButton`. Clicking "New company", "New contact", "New deal", and "Add provider" now opens the sheet and updates the URL.

- **Bug Fixes**
  - Typed `AddButton` as `ComponentProps<typeof Button>` and spread props to preserve `onClick`, aria, and data from `SheetTrigger asChild`; `disabled` still works.
  - Applied to: `companies/create-company-sheet.tsx`, `contacts/create-contact-sheet.tsx`, `deals/create-deal-sheet.tsx`, `settings/sso/add-sso-provider-sheet.tsx`.

<sup>Written for commit 5f8eb82ef0c799a9beb210c1f29b8f6537214201. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/42?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

