### PR TITLE
Fix/vercel same origin auth

### DIFF
--- a/apps/api/scripts/build-func.mjs
+++ b/apps/api/scripts/build-func.mjs
@@ -158,7 +158,7 @@ writeFileSync(
 	JSON.stringify({
 		version: 3,
 		routes: [{ src: "/(.*)", dest: "/api/index" }],
-		crons: [{ path: "/internal/sync/google", schedule: "*/5 * * * *" }],
+		crons: [{ path: "/internal/sync/google", schedule: "0 0 * * *" }],
 	}),
 );
 

--- a/apps/app/app/api/[...path]/route.ts
+++ b/apps/app/app/api/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { brotliDecompressSync, gunzipSync, inflateSync } from "node:zlib";
 import { connection } from "next/server";
-import { API_URL } from "@/lib/env";
+
+const upstreamApiUrl = process.env.API_URL ?? "http://localhost:3001";
 
 function decode(buf: Buffer, encoding: string | null): Buffer {
 	const enc = (encoding ?? "").toLowerCase();
@@ -16,7 +17,7 @@ async function handler(request: Request): Promise<Response> {
 	await connection();
 
 	const url = new URL(request.url);
-	const target = `${API_URL}${url.pathname}${url.search}`;
+	const target = `${upstreamApiUrl}${url.pathname}${url.search}`;
 
 	const headers = new Headers(request.headers);
 	for (const header of [
@@ -51,12 +52,12 @@ async function handler(request: Request): Promise<Response> {
 		upstream = await fetch(target, init);
 	} catch (error) {
 		console.error(
-			`API proxy: ${API_URL} is not reachable for ${request.method} ${url.pathname}.`,
+			`API proxy: ${upstreamApiUrl} is not reachable for ${request.method} ${url.pathname}.`,
 			error,
 		);
 
 		return Response.json(
-			{ error: `The API at ${API_URL} is not reachable.` },
+			{ error: `The API at ${upstreamApiUrl} is not reachable.` },
 			{ status: 502 },
 		);
 	}

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -4,8 +4,8 @@ import type { NextConfig } from "next";
 loadRootEnv();
 
 const apiUrl =
-	process.env.API_URL ??
 	process.env.NEXT_PUBLIC_API_URL ??
+	process.env.API_URL ??
 	"http://localhost:3001";
 
 const nextConfig: NextConfig = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore same-origin auth on Vercel by proxying API requests through the app origin and preferring `NEXT_PUBLIC_API_URL` over `API_URL`. Also change the `/internal/sync/google` cron to run daily at midnight.

<sup>Written for commit c4393036b36d04c83dfb4bd755d1a69bfd6beb9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

