### PR TITLE
Let aggregate money figures use the install's currency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,11 @@ GOOGLE_CLIENT_SECRET=""
 
 # PORT="3001"
 
+# The currency for figures that sum more than one deal — the overview tiles,
+# the stage donut, the table footers. A single deal always renders in its own
+# `Deal.currency`; these have no single deal to read. Defaults to "usd".
+# DEFAULT_CURRENCY="usd"
+
 
 # ── Optional: what the agent can do ──────────────────────────────────────────
 # The research agent works with none of these — it falls back to what the CRM

--- a/apps/app/next.config.ts
+++ b/apps/app/next.config.ts
@@ -8,9 +8,15 @@ const apiUrl =
 	process.env.NEXT_PUBLIC_API_URL ??
 	"http://localhost:3001";
 
+// Published for the same reason as `apiUrl`: the aggregate money figures are a
+// client component, and a value that lives only in the root `.env` is
+// `undefined` in the bundle.
+const defaultCurrency = process.env.DEFAULT_CURRENCY ?? "usd";
+
 const nextConfig: NextConfig = {
 	env: {
 		NEXT_PUBLIC_API_URL: apiUrl,
+		NEXT_PUBLIC_DEFAULT_CURRENCY: defaultCurrency,
 	},
 
 	transpilePackages: ["@crm/auth", "@crm/db", "@crm/telemetry", "@crm/ui"],

--- a/packages/ui/src/lib/format.ts
+++ b/packages/ui/src/lib/format.ts
@@ -4,6 +4,14 @@ export function formatCount(count: number, noun: string): string {
 
 const WELL_FORMED_CURRENCY_CODE = /^[A-Za-z]{3}$/;
 
+/**
+ * What to assume when a caller has no single deal to read a currency from —
+ * the KPI tiles, the stage donut, the table footers. Set
+ * `DEFAULT_CURRENCY` in `.env`; `next.config.ts` publishes it to the bundle.
+ */
+const DEFAULT_CURRENCY =
+	process.env.NEXT_PUBLIC_DEFAULT_CURRENCY?.trim() || "usd";
+
 function displayCurrencyCode(currency: string): string {
 	return WELL_FORMED_CURRENCY_CODE.test(currency)
 		? currency.toUpperCase()
@@ -26,7 +34,10 @@ function fractionDigits(code: string): number {
 	return digits;
 }
 
-export function formatMoney(cents: number, currency = "usd"): string {
+export function formatMoney(
+	cents: number,
+	currency = DEFAULT_CURRENCY,
+): string {
 	const code = displayCurrencyCode(currency);
 	const whole = cents % 100 === 0;
 	const digits = fractionDigits(code);
@@ -39,7 +50,10 @@ export function formatMoney(cents: number, currency = "usd"): string {
 	}).format(cents / 100);
 }
 
-export function formatMoneyCompact(cents: number, currency = "usd"): string {
+export function formatMoneyCompact(
+	cents: number,
+	currency = DEFAULT_CURRENCY,
+): string {
 	return new Intl.NumberFormat(undefined, {
 		style: "currency",
 		currency: displayCurrencyCode(currency),


### PR DESCRIPTION
Running this on an INR portal, the overview shows two different currencies for
the same money: the open-deals list renders each row in the deal's own
currency, and the "Open pipeline" tile directly above it renders the total as
US$. Same page, same deals.

Every per-deal call site passes `deal.currency`. The aggregates — the tiles,
the stage donut, the chart tooltips, the deals-table footer — have no single
deal to read one from, so they fall through to the hard-coded `"usd"` default
in `packages/ui/src/lib/format.ts`. It's invisible on a USD install, which is
presumably why it's lasted.

This adds `DEFAULT_CURRENCY`, published to the bundle the same way
`next.config.ts` already publishes `API_URL` — a value that only exists in the
root `.env` is `undefined` in a client bundle, so the `env` map is the
mechanism that already works here. Unset, nothing changes.

Not multi-currency (#19) — a single-tenant CRM has one reporting currency, and
this is just making that one value not be a constant. Mixed-currency portals
would still need real conversion.

Biome passes. I couldn't run `check-types` locally: `nestjs-trpc` ships no
`aarch64-pc-windows-msvc` binary, so the generate step can't run on this
machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aggregate money figures now use the install’s currency via `DEFAULT_CURRENCY`, fixing mixed USD/non-USD displays on overview tiles, stage donut, and table footers.

- **Bug Fixes**
  - Updated `formatMoney` and `formatMoneyCompact` in `packages/ui/src/lib/format.ts` to default to `NEXT_PUBLIC_DEFAULT_CURRENCY` instead of hard-coded `"usd"`.
  - `apps/app/next.config.ts` publishes `DEFAULT_CURRENCY` as `NEXT_PUBLIC_DEFAULT_CURRENCY`; added docs in `.env.example`.

- **Migration**
  - Set `DEFAULT_CURRENCY="inr"` (or your install currency) in `.env`. If unset, behavior stays `"usd"`.

<sup>Written for commit bfac068cd218a0e5456749a45cb55ba87ddd2faf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/45?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

