### PR TITLE
ci: open pull requests, gate titles and promote releases automatically

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,67 @@
+name: Auto PR
+
+on:
+  push:
+    branches-ignore:
+      - main
+      - release
+      - "release-please--**"
+      - "gh-readonly-queue/**"
+      - "dependabot/**"
+
+concurrency:
+  group: auto-pr-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open:
+    name: Open a draft pull request into main
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Open the pull request
+        env:
+          GH_TOKEN: ${{ secrets.AUTOMATION_TOKEN || secrets.GITHUB_TOKEN }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --head "$BRANCH" --state all --limit 1 --json number,state --jq '.[0] | select(.) | "#\(.number) (\(.state))"')
+          if [ -n "$existing" ]; then
+            echo "\`$BRANCH\` already has pull request $existing — leaving it alone." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          if [ "$(git rev-list --count "origin/main..origin/$BRANCH")" = "0" ]; then
+            echo "\`$BRANCH\` has nothing \`main\` does not already have." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          subject=$(git log "origin/main..origin/$BRANCH" --no-merges --reverse --format=%s | head -1)
+
+          if printf '%s' "$subject" | grep -Eq '^(feat|fix|perf|refactor|docs|revert|deps|chore|test|ci|build|style)(\([^)]+\))?!?: .+'; then
+            title="$subject"
+          else
+            title=$(printf '%s' "${BRANCH#*/}" | tr '_' ' ' | tr '-' ' ')
+          fi
+
+          body=$(cat <<EOF
+          Opened automatically when \`$BRANCH\` was pushed.
+
+          This pull request is squashed onto \`main\`, so **its title becomes the commit subject and the changelog line**. Make it a [Conventional Commit](https://www.conventionalcommits.org/) — \`feat(app): …\`, \`fix(api): …\` — before marking it ready for review, which is when the title is checked.
+
+          The type decides the version bump: \`feat\` is a minor, \`fix\` / \`perf\` / \`refactor\` / \`docs\` are a patch, a trailing \`!\` is a major, and \`chore\` / \`ci\` / \`test\` / \`build\` / \`style\` release nothing at all.
+          EOF
+          )
+
+          gh pr create --draft --base main --head "$BRANCH" --title "$title" --body "$body"
+
+          echo "Opened a draft pull request for \`$BRANCH\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    branches: [main, release]
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,70 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  conventional:
+    name: conventional commit
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        id: lint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            docs
+            revert
+            deps
+            chore
+            test
+            ci
+            build
+            style
+          requireScope: false
+          subjectPattern: ^(?![A-Z][a-z]).+[^.]$
+          subjectPatternError: >-
+            The subject "{subject}" of "{title}" reads like a sentence, not a
+            changelog line. Start it lowercase and in the imperative, and drop
+            the trailing full stop — "add bulk archive to the deals table",
+            not "Added bulk archive."
+
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: always()
+        continue-on-error: true
+        with:
+          header: pr-title
+          delete: ${{ steps.lint.outputs.error_message == null }}
+          message: |
+            **This pull request's title is not a Conventional Commit.**
+
+            It is squashed onto `main` as-is, so the title is the commit subject and the line that shows up in the changelog and the release notes.
+
+            ```
+            ${{ steps.lint.outputs.error_message }}
+            ```
+
+            | Title | Bump | Changelog heading |
+            | --- | --- | --- |
+            | `feat(app): add bulk archive to the deals table` | minor | Features |
+            | `fix(api): stop double-counting installs` | patch | Fixes |
+            | `feat(db)!: drop the legacy contacts table` | major | Features, flagged breaking |
+            | `chore(deps): bump turbo to 2.11` | none | hidden |
+
+            Edit the title and this check re-runs on its own.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,16 +14,41 @@ permissions:
 
 jobs:
   release-please:
+    name: Release pull request, tag and notes
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     outputs:
       released: ${{ steps.release.outputs.release_created }}
       tag: ${{ steps.release.outputs.tag_name }}
-      version: ${{ steps.release.outputs.version }}
+      sha: ${{ steps.release.outputs.sha }}
+      url: ${{ steps.release.outputs.html_url }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           config-file: .github/release-please-config.json
           manifest-file: .github/.release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTOMATION_TOKEN || secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+  promote:
+    name: Fast-forward release
+    needs: release-please
+    if: needs.release-please.outputs.released == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Move release to ${{ needs.release-please.outputs.tag }}
+        env:
+          SHA: ${{ needs.release-please.outputs.sha }}
+          TAG: ${{ needs.release-please.outputs.tag }}
+          URL: ${{ needs.release-please.outputs.url }}
+        run: |
+          set -euo pipefail
+          git push origin "$SHA:refs/heads/release"
+          echo "\`release\` now points at [$TAG]($URL)." >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ context until you read them, and the rules in them are not optional.
 | The record sheet's Agent tab | `docs/agent-panel.md` |
 | Running it locally, Google Cloud, DB commands, secrets | `docs/setup.md` |
 | Anything that sends a telemetry event, or a new property on one | `docs/telemetry.md` |
+| `.github/workflows`, versions, changelog, how a change reaches `release` | `CONTRIBUTING.md` |
 
 Also check `.agents/skills/` for a relevant skill before starting — better-auth,
 prisma, nestjs-trpc, eve, shadcn, nuqs and others have one. Tell the user which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,6 +123,27 @@ Three consequences worth knowing:
 protection requiring the `check-types, lint, test` and `conventional commit` checks** — not the
 release workflow, which cannot wait on a run in another workflow.
 
+### When it jams
+
+The Release workflow reports success even when it has done nothing, so the symptom of a jam is
+silence: merges land, no release PR appears. Read the log rather than the status. Two failures have
+actually happened here:
+
+- **`There are untagged, merged release PRs outstanding - aborting`.** A release PR was merged but
+  never tagged, and release-please refuses to move past it — every later run aborts on the same PR,
+  which is how this repo sat from `v1.0.0` in August with no tags at all. Fix it by hand: create the
+  tag and GitHub Release at the release PR's merge commit, then swap that PR's
+  `autorelease: pending` label for `autorelease: tagged`. The next run picks up where it left off.
+  The usual cause is a release PR whose title does not match `pull-request-title-pattern`, because
+  the version is parsed back out of that title — so do not edit the pattern with a release PR open.
+- **`commit could not be parsed`, in bulk.** Non-conventional subjects reached `main`. They are not
+  errors, they are silently missing changelog lines. The squash-only merge policy and the
+  `conventional commit` check exist to stop this; if you see it again, one of the two has been
+  turned off.
+
+`workflow_dispatch` is enabled on the workflow, so you can re-run it against `main` from the Actions
+tab once you have fixed the cause, instead of pushing an empty commit.
+
 ## House style
 
 The repo has opinions, and they're written down where the work happens rather than in a style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,42 +51,77 @@ A few things that trip people up:
   to `apps/api/src/config/env.validation.ts`. A variable that only exists in someone's shell is a
   variable that breaks the next person's clone.
 
-## Releases
+## Shipping a change
 
-Releases are cut by [release-please](https://github.com/googleapis/release-please), so **your commit
-subject is the release note**. Write it for somebody reading the changelog six months from now, not
-for the diff.
+Push a branch and the rest is mechanical. There are exactly two things you click.
 
-Subjects follow [Conventional Commits](https://www.conventionalcommits.org/), which the history
-already does — `feat(api):`, `fix(db):`, `refactor(agent):`. The type decides both the version bump
-and the heading it appears under:
+```
+push a branch ──▶ draft PR opens by itself
+                        │
+                  you title it, mark it ready, CI runs
+                        │
+                  ◀── click 1: squash into main
+                        │
+                  release PR opens or updates itself
+                        │
+                  ◀── click 2: merge it
+                        │
+        tag + GitHub Release + CHANGELOG.md, and `release` moves up
+```
 
-| Subject | Bump | Appears under |
+**Pushing any branch that isn't `main` or `release` opens a draft pull request into `main`.** You do
+not create it, and re-pushing does not create a second one. If you close it on purpose it stays
+closed. The title is guessed from your first commit subject, which is usually wrong — fixing it is
+the one thing the automation cannot do for you.
+
+**The pull request title is the release note.** The repo squashes, so the title becomes the commit
+subject on `main`, and that subject is the line somebody reads in the changelog six months from now.
+Write it for them, not for the diff. It has to be a
+[Conventional Commit](https://www.conventionalcommits.org/) — `feat(api): …`, `fix(db): …` — and the
+`PR title` check enforces that the moment the PR leaves draft. Drafts are deliberately exempt, so an
+auto-opened PR does not sit there red while you are still working.
+
+The type decides both the version bump and the heading it appears under:
+
+| Title | Bump | Appears under |
 | --- | --- | --- |
 | `feat(app): …` | minor | Features |
 | `fix(db): …` | patch | Fixes |
 | `perf:`, `refactor:`, `docs:`, `revert:` | patch | their own heading |
+| `feat(db)!: …` | major | Features, flagged as breaking |
 | `chore:`, `ci:`, `test:`, `build:`, `style:` | none | nothing — deliberately invisible |
 
-Nothing is released by the merge itself. Merging to `main` opens or updates a single
-`chore(release): 0.2.0` pull request that accumulates the changelog and bumps the version; **merging
-that PR** is what tags `v0.2.0` and publishes the GitHub Release. So the notes are reviewable before
-they are public, and a stack of merges is one release rather than five.
+The `!` is how you declare a break. A `BREAKING CHANGE:` footer in the body will not work here,
+because the squashed commit body is left empty on purpose — the title is the whole record.
 
-Two consequences worth knowing:
+## Releases
+
+Nothing is released by merging to `main`. Merging opens or updates a single
+`chore(release): 0.2.0` pull request from [release-please](https://github.com/googleapis/release-please)
+that accumulates the changelog and bumps the version; **merging that PR** is what tags `v0.2.0`,
+publishes the GitHub Release, and writes `CHANGELOG.md`. So the notes are reviewable before they are
+public, and a stack of merges is one release rather than five.
+
+Once the tag exists, the `release` branch is fast-forwarded onto it automatically. `release` is
+therefore never anything but the last released commit, which is what makes it safe to point a
+production deploy at. There is no second pull request to merge — the release PR was the gate.
+
+Three consequences worth knowing:
 
 - **A release PR with nothing in it is not a bug.** A run of `chore:` and `test:` commits bumps
   nothing, so no PR appears. That is the type doing its job.
 - **The release PR does not run CI.** A PR opened by `GITHUB_TOKEN` cannot trigger workflows — that
   is GitHub's own loop guard, not something to work around. It is safe because the PR only ever
   touches `CHANGELOG.md`, the root `version`, and the release manifest, and because CI runs again on
-  `main` after it lands. Setting a `RELEASE_PLEASE_TOKEN` secret (a PAT or a GitHub App token) makes
-  the PR run CI like any other; the workflow already prefers it and falls back to `GITHUB_TOKEN`, so
-  it is an upgrade rather than a requirement.
+  `main` after it lands. The same guard is why an auto-opened draft PR shows no checks until you
+  push to it or mark it ready.
+- **An `AUTOMATION_TOKEN` secret removes that caveat.** A PAT or GitHub App token makes both the
+  release PR and the auto-opened PR trigger CI like any other. Every workflow already prefers it and
+  falls back to `GITHUB_TOKEN`, so it is an upgrade rather than a requirement.
 
 `main` is expected to be green when a tag is cut, and the thing that guarantees that is **branch
-protection requiring the `check-types, lint, test` check** — not the release workflow, which cannot
-wait on a run in another workflow.
+protection requiring the `check-types, lint, test` and `conventional commit` checks** — not the
+release workflow, which cannot wait on a run in another workflow.
 
 ## House style
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "crm",
 	"private": true,
 	"license": "MIT",
-	"version": "1.0.1",
+	"version": "1.0.0",
 	"scripts": {
 		"build": "turbo run build",
 		"dev": "turbo run dev",


### PR DESCRIPTION
Pushing a branch now opens its own draft PR, and merging one release PR is the only thing that cuts a version.

```
push a branch ──▶ draft PR opens by itself
                  ◀── click 1: squash into main
                  release PR opens or updates itself
                  ◀── click 2: merge it
        tag + GitHub Release + CHANGELOG.md, and `release` moves up
```

### What's here

- **`auto-pr.yml`** — any branch that isn't `main`/`release` gets a draft PR into `main` on push. It won't open a second one, and it won't reopen one you closed. The title is seeded from your first commit subject when that subject is already conventional, otherwise from the branch name.
- **`pr-title.yml`** — the PR title has to be a Conventional Commit, checked only once the PR leaves draft so auto-opened drafts don't sit there red. A sticky comment explains the fix and clears itself once the title is right.
- **`release.yml`** — release-please moved to v5 (v4 runs on deprecated Node 20), plus a `promote` job that fast-forwards `release` onto each new tag.
- **`ci.yml`** — also runs on `ready_for_review` and on `release`.

### Why the title check is the load-bearing part

Release-please builds the changelog from commit subjects on `main`. The last run parsed **38 commits and rejected every one of them** — `Merge pull request #31 from …`, `Enhance currency handling and conversion logic`. Nothing conventional means nothing in the changelog.

Squash-merging with the PR title as the subject fixes that at one chokepoint instead of asking anyone to rewrite commits. That's why this PR wants the repo set to squash-only with `PR_TITLE` as the commit title.

Because the body is left blank on purpose, `BREAKING CHANGE:` footers won't work — declare breaks with `feat!:`.

### Separately: release-please is currently wedged

Not fixed by this PR, it needs repo surgery. PR #9 (`chore: release main`) merged on Aug 3 but was never tagged, because its title predates the configured `pull-request-title-pattern` and no version can be parsed out of it. Every run since has aborted with:

> ⚠ There are untagged, merged release PRs outstanding - aborting

So there are no tags and no releases on this repo at all. Creating `v1.0.0` at 6b10b5b and relabelling PR #9 `autorelease: tagged` clears it permanently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates the path from branch to release: pushing any branch opens a draft PR, titles are enforced as Conventional Commits when leaving draft, and releases are created only by merging the `release-please` PR which also fast‑forwards `release`. Adds manual `workflow_dispatch` for the Release workflow and documents how to unjam `release-please`.

- **New Features**
  - Auto PR: non-`main`/`release` pushes open one draft PR into `main`; title seeded from first conventional subject or branch name; no duplicates.
  - Title check: lints non-draft PR titles for Conventional Commits, posts a sticky hint, and uses the title as the squash commit subject/changelog line.
  - Release: `release-please` v5; new promote step fast‑forwards `release` to each new tag; prefers `AUTOMATION_TOKEN` and falls back to `GITHUB_TOKEN`; can be run manually via `workflow_dispatch`.
  - CI: triggers on `ready_for_review` and pushes to `main` and `release`.

- **Migration**
  - Set squash-only merges and “use PR title as commit message.”
  - Require `check-types`, `lint`, `test`, and `conventional commit` in branch protection.
  - Optionally add `AUTOMATION_TOKEN` so auto-opened and release PRs trigger workflows; otherwise `GITHUB_TOKEN` is used.
  - If `release-please` is wedged on an untagged merged release PR, follow the new “When it jams” steps in `CONTRIBUTING.md` (create the tag, relabel the PR, then re-run Release via `workflow_dispatch`).

<sup>Written for commit fdd0b63a932dd00bce5688b1fd0339ddcdc1f4cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

