### PR TITLE
feat(deals): add and remove people on a deal

### DIFF
--- a/apps/api/src/deals/deals.contracts.ts
+++ b/apps/api/src/deals/deals.contracts.ts
@@ -74,3 +74,18 @@ export const setStageInput = z.object({
 });
 
 export type SetStageInput = z.infer<typeof setStageInput>;
+
+export const dealAddContactInput = z.object({
+	dealId: z.string().min(1),
+	contactId: z.string().min(1),
+	role: z.string().trim().optional(),
+});
+
+export type DealAddContactInput = z.infer<typeof dealAddContactInput>;
+
+export const dealRemoveContactInput = z.object({
+	dealId: z.string().min(1),
+	contactId: z.string().min(1),
+});
+
+export type DealRemoveContactInput = z.infer<typeof dealRemoveContactInput>;

--- a/apps/api/src/deals/deals.router.ts
+++ b/apps/api/src/deals/deals.router.ts
@@ -11,9 +11,11 @@ import type { z } from "zod";
 import type { AuthedTrpcContext } from "../trpc/context.types";
 import { AuthMiddleware } from "../trpc/middlewares/auth.middleware";
 import {
+	dealAddContactInput,
 	dealCreateInput,
 	dealIdInput,
 	dealListInput,
+	dealRemoveContactInput,
 	dealUpdateArgs,
 	setStageInput,
 } from "./deals.contracts";
@@ -55,5 +57,15 @@ export class DealsRouter {
 		@Input() input: z.infer<typeof setStageInput>,
 	) {
 		return this.deals.setStage(input, ctx.user.id);
+	}
+
+	@Mutation({ input: dealAddContactInput })
+	async addContact(@Input() input: z.infer<typeof dealAddContactInput>) {
+		return this.deals.addContact(input);
+	}
+
+	@Mutation({ input: dealRemoveContactInput })
+	async removeContact(@Input() input: z.infer<typeof dealRemoveContactInput>) {
+		return this.deals.removeContact(input);
 	}
 }

--- a/apps/api/src/deals/deals.service.ts
+++ b/apps/api/src/deals/deals.service.ts
@@ -40,8 +40,10 @@ import {
 } from "./deal-stage";
 import type {
 	ClosingWindow,
+	DealAddContactInput,
 	DealCreateInput,
 	DealListInput,
+	DealRemoveContactInput,
 	DealUpdateInput,
 	SetStageInput,
 } from "./deals.contracts";
@@ -405,6 +407,122 @@ export class DealsService {
 		});
 
 		return { ...updated, changed: true };
+	}
+
+
+	async addContact(input: DealAddContactInput) {
+		const deal = await this.db.deal.findUnique({
+			where: { id: input.dealId },
+			select: { id: true, companyId: true },
+		});
+		if (!deal) {
+			throw new NotFoundException(`No deal with id ${input.dealId}.`);
+		}
+
+		const contact = await this.db.contact.findUnique({
+			where: { id: input.contactId },
+			select: {
+				id: true,
+				companyId: true,
+				firstName: true,
+				lastName: true,
+			},
+		});
+		if (!contact) {
+			throw new NotFoundException(`No contact with id ${input.contactId}.`);
+		}
+		if (contact.companyId !== deal.companyId) {
+			throw new BadRequestException(
+				"That contact does not work at the company on this deal.",
+			);
+		}
+
+		const role = blankToNull(input.role ?? "");
+
+		const link = await this.db.dealContact.upsert({
+			where: {
+				dealId_contactId: {
+					dealId: deal.id,
+					contactId: contact.id,
+				},
+			},
+			create: {
+				dealId: deal.id,
+				contactId: contact.id,
+				role,
+			},
+			update: {
+				role,
+			},
+			select: {
+				dealId: true,
+				contactId: true,
+				role: true,
+			},
+		});
+
+		await this.stamp.touch(
+			{ companyId: deal.companyId, dealId: deal.id, contactId: contact.id },
+			new Date(),
+		);
+
+		this.logger.log({
+			message: "Deal contact attached",
+			dealId: deal.id,
+			contactId: contact.id,
+		});
+
+		return link;
+	}
+
+	async removeContact(input: DealRemoveContactInput) {
+		const deal = await this.db.deal.findUnique({
+			where: { id: input.dealId },
+			select: { id: true, companyId: true },
+		});
+		if (!deal) {
+			throw new NotFoundException(`No deal with id ${input.dealId}.`);
+		}
+
+		try {
+			await this.db.dealContact.delete({
+				where: {
+					dealId_contactId: {
+						dealId: input.dealId,
+						contactId: input.contactId,
+					},
+				},
+			});
+		} catch (error) {
+			if (
+				error instanceof PrismaNamespace.PrismaClientKnownRequestError &&
+				error.code === "P2025"
+			) {
+				throw new NotFoundException("That person is not on this deal.");
+			}
+			throw error;
+		}
+
+		await this.stamp.touch(
+			{
+				companyId: deal.companyId,
+				dealId: deal.id,
+				contactId: input.contactId,
+			},
+			new Date(),
+		);
+
+		this.logger.log({
+			message: "Deal contact removed",
+			dealId: deal.id,
+			contactId: input.contactId,
+		});
+
+		return {
+			dealId: deal.id,
+			contactId: input.contactId,
+			removed: true as const,
+		};
 	}
 
 	private searchFilter(q: string): Prisma.DealWhereInput {

--- a/apps/api/src/generated/server.ts
+++ b/apps/api/src/generated/server.ts
@@ -19,7 +19,7 @@ import { contactListInput, contactIdInput, contactCreateInput, contactUpdateArgs
 import { conversationListInput, conversationEventsInput, conversationSaveInput, conversationIdInput } from "../conversations/conversations.contracts";
 import { setReportingCurrencyInput, setManualRateInput, removeManualRateInput } from "../currency/currency.contracts";
 import { dashboardSummaryInput } from "../dashboard/dashboard.contracts";
-import { dealListInput, dealIdInput, dealCreateInput, dealUpdateArgs, setStageInput } from "../deals/deals.contracts";
+import { dealListInput, dealIdInput, dealCreateInput, dealUpdateArgs, setStageInput, dealAddContactInput, dealRemoveContactInput } from "../deals/deals.contracts";
 import { setAutoCreateInput, suppressDomainInput, threadInput, calendarEventInput } from "../google/google.contracts";
 import { setAgentModelInput, setResearchKeyInput } from "../settings/settings.contracts";
 import { ssoProviderListInput, registerSsoProviderInput, deleteSsoProviderInput } from "../sso/sso.contracts";
@@ -160,7 +160,13 @@ const appRouter = t.router({
       .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["delete"]>>),
     setStage: publicProcedure
       .input(setStageInput)
-      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["setStage"]>>)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["setStage"]>>),
+    addContact: publicProcedure
+      .input(dealAddContactInput)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["addContact"]>>),
+    removeContact: publicProcedure
+      .input(dealRemoveContactInput)
+      .mutation(async () => "PLACEHOLDER_DO_NOT_REMOVE" as unknown as Awaited<ReturnType<DealsRouter["removeContact"]>>)
     }),
   google: t.router({
     status: publicProcedure

--- a/apps/app/components/crm/record-sheet/deal-sheet.tsx
+++ b/apps/app/components/crm/record-sheet/deal-sheet.tsx
@@ -1,14 +1,28 @@
 "use client";
 
+import Add from "@carbon/icons-react/es/Add";
+import TrashCan from "@carbon/icons-react/es/TrashCan";
 import UserMultiple from "@carbon/icons-react/es/UserMultiple";
 import { CURRENCIES, normalizeCurrency } from "@crm/db/currency";
+import { Button } from "@crm/ui/components/button";
 import { EmptyCellValue } from "@crm/ui/components/empty-cell";
 import {
 	EntityLogo,
 	type EntityLogoTone,
 } from "@crm/ui/components/entity-logo";
+import { Field, FieldLabel } from "@crm/ui/components/field";
+import { Icon } from "@crm/ui/components/icon";
+import { Input } from "@crm/ui/components/input";
 import { PersonAvatar } from "@crm/ui/components/person-avatar";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@crm/ui/components/select";
 import { SimpleTable, SimpleTableRow } from "@crm/ui/components/simple-table";
+import { Spinner } from "@crm/ui/components/spinner";
 import { TableCell } from "@crm/ui/components/table";
 import {
 	formatDay,
@@ -16,6 +30,7 @@ import {
 	relativeTimeFromIso,
 } from "@crm/ui/lib/format";
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { useId, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { AgentPanel } from "@/components/crm/agent-panel";
 import { contactName } from "@/components/crm/contact-name";
@@ -91,10 +106,11 @@ function ReportedValue({ deal }: { deal: Deal }) {
 }
 
 const CONTACT_COLUMNS = [
-	{ header: "Name", width: "w-[30%]", className: "pl-5" },
-	{ header: "Role", width: "w-[20%]" },
-	{ header: "Title", width: "w-[25%]" },
-	{ header: "Email", width: "w-[25%]" },
+	{ header: "Name", width: "w-[28%]", className: "pl-5" },
+	{ header: "Role", width: "w-[18%]" },
+	{ header: "Title", width: "w-[22%]" },
+	{ header: "Email", width: "w-[22%]" },
+	{ header: "", width: "w-[10%]", className: "pr-5 text-right" },
 ];
 
 const dateFormat = new Intl.DateTimeFormat(undefined, {
@@ -107,6 +123,7 @@ export function DealSheet({ dealId }: { dealId: string }) {
 	const trpc = useTRPC();
 	const openRecord = useOpenRecord();
 	const { tab, setTab } = useRecordSheetView("overview");
+	const [addingContact, setAddingContact] = useState(false);
 
 	const query = useQuery(trpc.deals.byId.queryOptions({ id: dealId }));
 	const deal = query.data;
@@ -122,7 +139,14 @@ export function DealSheet({ dealId }: { dealId: string }) {
 					value: "contacts",
 					label: "Contacts",
 					count: deal.contacts.length,
-					content: <DealContacts deal={deal} />,
+					content: (
+						<DealContacts
+							deal={deal}
+							adding={addingContact}
+							onAdd={() => setAddingContact(true)}
+							onDone={() => setAddingContact(false)}
+						/>
+					),
 				},
 				{
 					value: "activity",
@@ -379,49 +403,253 @@ function WhereItStands({ deal }: { deal: Deal }) {
 	);
 }
 
-function DealContacts({ deal }: { deal: Deal }) {
+function DealContacts({
+	deal,
+	adding,
+	onAdd,
+	onDone,
+}: {
+	deal: Deal;
+	adding: boolean;
+	onAdd: () => void;
+	onDone: () => void;
+}) {
+	const trpc = useTRPC();
+	const cache = useCrmCache();
 	const openRecord = useOpenRecord();
+
+	const company = useQuery({
+		...trpc.companies.byId.queryOptions({ id: deal.company.id }),
+		enabled: adding,
+	});
+
+	const attachedIds = useMemo(
+		() => new Set(deal.contacts.map((contact) => contact.id)),
+		[deal.contacts],
+	);
+
+	const candidates = (company.data?.contacts ?? []).filter(
+		(contact) => !attachedIds.has(contact.id),
+	);
+
+	const remove = useMutation(
+		trpc.deals.removeContact.mutationOptions({
+			onSuccess: async () => {
+				await cache.deal(deal.id);
+				toast.success("Removed from this deal.");
+			},
+			onError: (error) => toast.error(error.message),
+		}),
+	);
+
+	const form = adding ? (
+		<AddDealContactForm
+			dealId={deal.id}
+			companyName={deal.company.name}
+			candidates={candidates}
+			loading={company.isPending}
+			onDone={onDone}
+		/>
+	) : null;
 
 	if (deal.contacts.length === 0) {
 		return (
-			<DetailSheetEmpty
-				icon={UserMultiple}
-				title="No contacts on this deal"
-				description={`Nobody from ${deal.company.name} is attached yet. Add people to the company, then bring them onto the deal.`}
-			/>
+			<>
+				{form}
+				{adding ? null : (
+					<DetailSheetEmpty
+						icon={UserMultiple}
+						title="No contacts on this deal"
+						description={`Nobody from ${deal.company.name} is attached yet. Pick people from the company to bring them onto the deal.`}
+						action={
+							<Button variant="outline" size="sm" onClick={onAdd}>
+								<Icon icon={Add} data-icon="inline-start" />
+								Add person
+							</Button>
+						}
+					/>
+				)}
+			</>
 		);
 	}
 
 	return (
-		<SimpleTable variant="panel" columns={CONTACT_COLUMNS}>
-			{deal.contacts.map((contact) => (
-				<SimpleTableRow
-					key={contact.id}
-					clickable
-					onClick={() => openRecord({ kind: "contact", id: contact.id })}
-				>
-					<TableCell className="truncate py-2.5 pr-3 pl-5 font-medium">
-						<span className="flex min-w-0 items-center gap-2">
-							<PersonAvatar
-								src={contact.imageUrl}
-								name={contactName(contact)}
-								email={contact.email}
-								size="sm"
+		<>
+			{form}
+			{adding ? null : (
+				<div className="flex justify-end border-b px-5 py-3">
+					<Button variant="outline" size="sm" onClick={onAdd}>
+						<Icon icon={Add} data-icon="inline-start" />
+						Add person
+					</Button>
+				</div>
+			)}
+			<SimpleTable variant="panel" columns={CONTACT_COLUMNS}>
+				{deal.contacts.map((contact) => (
+					<SimpleTableRow
+						key={contact.id}
+						clickable
+						onClick={() => openRecord({ kind: "contact", id: contact.id })}
+					>
+						<TableCell className="truncate py-2.5 pr-3 pl-5 font-medium">
+							<span className="flex min-w-0 items-center gap-2">
+								<PersonAvatar
+									src={contact.imageUrl}
+									name={contactName(contact)}
+									email={contact.email}
+									size="sm"
+								/>
+								<span className="truncate">{contactName(contact)}</span>
+							</span>
+						</TableCell>
+						<TableCell className="truncate px-3 py-2.5">
+							{contact.role ?? <EmptyCellValue />}
+						</TableCell>
+						<TableCell className="truncate px-3 py-2.5 text-muted-foreground">
+							{contact.title ?? <EmptyCellValue />}
+						</TableCell>
+						<TableCell className="truncate px-3 py-2.5 text-muted-foreground">
+							{contact.email ?? <EmptyCellValue />}
+						</TableCell>
+						<TableCell className="py-2.5 pr-5 text-right">
+							<Button
+								variant="ghost"
+								size="icon-xs"
+								disabled={remove.isPending}
+								onClick={(event) => {
+									event.stopPropagation();
+									remove.mutate({
+										dealId: deal.id,
+										contactId: contact.id,
+									});
+								}}
+							>
+								<Icon icon={TrashCan} />
+								<span className="sr-only">Remove from deal</span>
+							</Button>
+						</TableCell>
+					</SimpleTableRow>
+				))}
+			</SimpleTable>
+		</>
+	);
+}
+
+function AddDealContactForm({
+	dealId,
+	companyName,
+	candidates,
+	loading,
+	onDone,
+}: {
+	dealId: string;
+	companyName: string;
+	candidates: {
+		id: string;
+		firstName: string;
+		lastName: string | null;
+		email: string | null;
+		title: string | null;
+	}[];
+	loading: boolean;
+	onDone: () => void;
+}) {
+	const trpc = useTRPC();
+	const cache = useCrmCache();
+	const [contactId, setContactId] = useState("");
+	const [role, setRole] = useState("");
+	const contactFieldId = useId();
+	const roleId = useId();
+
+	const add = useMutation(
+		trpc.deals.addContact.mutationOptions({
+			onSuccess: async () => {
+				await cache.deal(dealId);
+				toast.success("Added to this deal.");
+				onDone();
+			},
+			onError: (error) => toast.error(error.message),
+		}),
+	);
+
+	return (
+		<form
+			className="flex shrink-0 flex-col gap-4 border-b px-5 py-4"
+			onSubmit={(event) => {
+				event.preventDefault();
+				if (!contactId) {
+					toast.error("Pick someone from the company.");
+					return;
+				}
+				add.mutate({
+					dealId,
+					contactId,
+					role: role || undefined,
+				});
+			}}
+		>
+			<div className="grid gap-4 sm:grid-cols-2">
+				<Field>
+					<FieldLabel htmlFor={contactFieldId}>Person</FieldLabel>
+					<Select
+						value={contactId || undefined}
+						onValueChange={setContactId}
+						disabled={loading || candidates.length === 0}
+					>
+						<SelectTrigger id={contactFieldId}>
+							<SelectValue
+								placeholder={
+									loading
+										? "Loading people…"
+										: candidates.length === 0
+											? `No one left at ${companyName}`
+											: "Select a person"
+								}
 							/>
-							<span className="truncate">{contactName(contact)}</span>
-						</span>
-					</TableCell>
-					<TableCell className="truncate px-3 py-2.5">
-						{contact.role ?? <EmptyCellValue />}
-					</TableCell>
-					<TableCell className="truncate px-3 py-2.5 text-muted-foreground">
-						{contact.title ?? <EmptyCellValue />}
-					</TableCell>
-					<TableCell className="truncate px-3 py-2.5 text-muted-foreground">
-						{contact.email ?? <EmptyCellValue />}
-					</TableCell>
-				</SimpleTableRow>
-			))}
-		</SimpleTable>
+						</SelectTrigger>
+						<SelectContent>
+							{candidates.map((contact) => {
+								const name = contactName(contact);
+								return (
+									<SelectItem key={contact.id} value={contact.id}>
+										{name}
+										{contact.title ? ` · ${contact.title}` : ""}
+									</SelectItem>
+								);
+							})}
+						</SelectContent>
+					</Select>
+				</Field>
+				<Field>
+					<FieldLabel htmlFor={roleId}>Role on deal</FieldLabel>
+					<Input
+						id={roleId}
+						value={role}
+						onChange={(event) => setRole(event.target.value)}
+						placeholder="Champion, Decision maker…"
+						autoComplete="off"
+					/>
+				</Field>
+			</div>
+			<div className="flex items-center justify-end gap-2">
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					disabled={add.isPending}
+					onClick={onDone}
+				>
+					Cancel
+				</Button>
+				<Button
+					type="submit"
+					size="sm"
+					disabled={add.isPending || !contactId || candidates.length === 0}
+				>
+					{add.isPending ? <Spinner /> : null}
+					Add to deal
+				</Button>
+			</div>
+		</form>
 	);
 }


### PR DESCRIPTION
## Summary
Fixes #57.

Deal Contacts tab previously rendered only an empty state (“bring them onto the deal”) with **no API or UI** to attach/detach people, despite `DealContact` existing in the schema and being returned by `deals.byId`.

### Changes
- **API:** `deals.addContact({ dealId, contactId, role? })` upserts `dealContact`
- **API:** `deals.removeContact({ dealId, contactId })` deletes the link
- Validates the contact belongs to the deal’s company
- Optional role; re-attach updates role
- Touches activity stamps on attach/remove
- **UI:** Add person on the deal Contacts tab (picker of company contacts not already attached + optional role) and per-row remove
- Regenerated nestjs-trpc placeholders for the new mutations

### Test plan
- [ ] Company with contacts + deal with none → empty state has **Add person**
- [ ] Attach person + role → row appears; tab count updates
- [ ] Remove person → gone from deal, contact remains on company
- [ ] Contact from another company is rejected by API
- [ ] Re-attach same person with a new role updates role

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the ability to attach and remove people on a deal from the Contacts tab. Adds server mutations with company-scoped validation and a simple UI with an optional role field.

- **New Features**
  - API: `deals.addContact({ dealId, contactId, role? })` upserts the link; `deals.removeContact({ dealId, contactId })` deletes it; validates the contact belongs to the deal’s company; re-attach updates role.
  - UI: Contacts tab now has an “Add person” form (picker of company contacts not already attached + role input) and per-row Remove; tab count updates; success/error toasts and loading states.
  - Activity: Touches activity stamps on attach and remove.

<sup>Written for commit 4135bcf8c309942d21e7f64507a0d3db543a6064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

