### PR TITLE
propose fireflies transcript integration

### DIFF
--- a/adrs/fireflies-integration.md
+++ b/adrs/fireflies-integration.md
@@ -1,0 +1,1 @@
+representatives richest conversations happen in meetings, and the CRM currently sees only that a meeting occurred, not what was said. add an optional Fireflies capability (keyed by FIREFLIES_API_KEY) so the agent can fetch the transcript for a synced calendar event and feed it through the existing evidence pipeline. if unset, nothing changes. 


### PR DESCRIPTION
hello comp ai team, first of all thanks for creating this handy crm and making it public.

my company is planning to use it internally as well and while testing I noticed that the agent is missing some context about topics discussed in meetings. we use fireflies to record transcripts and generate summaries, so I am proposing to add an optional integration for it. 

 we'll implement it anyways, so please let me know wether this is something to be accepted to the root trycompai/crm repo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ADR proposing an optional Fireflies integration to pull meeting transcripts into the CRM so agents have meeting context. It uses `FIREFLIES_API_KEY` and feeds transcripts into the existing evidence pipeline; if the key is not set, nothing changes.

<sup>Written for commit f3acbbec9e14b23754f4565347a7055dbc6c3e96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

