### PR TITLE
Refactor query prefetching in Companies, Contacts, and Deals pages to…

### DIFF
--- a/apps/app/app/(app)/[slug]/companies/page.tsx
+++ b/apps/app/app/(app)/[slug]/companies/page.tsx
@@ -56,10 +56,12 @@ async function Companies({
 
 	const trpc = getServerTrpc();
 	const queryClient = getServerQueryClient();
-	await queryClient.prefetchQuery(
-		trpc.companies.list.queryOptions(companiesSearchParams.toInput(values)),
-	);
-	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
+	await Promise.all([
+		queryClient.prefetchQuery(
+			trpc.companies.list.queryOptions(companiesSearchParams.toInput(values)),
+		),
+		queryClient.prefetchQuery(trpc.users.list.queryOptions()),
+	]);
 
 	return (
 		<HydrateClient>

--- a/apps/app/app/(app)/[slug]/contacts/page.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/page.tsx
@@ -54,13 +54,13 @@ async function Contacts({
 
 	const trpc = getServerTrpc();
 	const queryClient = getServerQueryClient();
-	await queryClient.prefetchQuery(
-		trpc.contacts.list.queryOptions(contactsSearchParams.toInput(values)),
-	);
-	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
-	void queryClient.prefetchQuery(
-		trpc.companies.options.queryOptions({ q: "" }),
-	);
+	await Promise.all([
+		queryClient.prefetchQuery(
+			trpc.contacts.list.queryOptions(contactsSearchParams.toInput(values)),
+		),
+		queryClient.prefetchQuery(trpc.users.list.queryOptions()),
+		queryClient.prefetchQuery(trpc.companies.options.queryOptions({ q: "" })),
+	]);
 
 	return (
 		<HydrateClient>

--- a/apps/app/app/(app)/[slug]/deals/page.tsx
+++ b/apps/app/app/(app)/[slug]/deals/page.tsx
@@ -56,13 +56,13 @@ async function Deals({
 
 	const trpc = getServerTrpc();
 	const queryClient = getServerQueryClient();
-	await queryClient.prefetchQuery(
-		trpc.deals.list.queryOptions(dealsSearchParams.toInput(values)),
-	);
-	void queryClient.prefetchQuery(trpc.users.list.queryOptions());
-	void queryClient.prefetchQuery(
-		trpc.companies.options.queryOptions({ q: "" }),
-	);
+	await Promise.all([
+		queryClient.prefetchQuery(
+			trpc.deals.list.queryOptions(dealsSearchParams.toInput(values)),
+		),
+		queryClient.prefetchQuery(trpc.users.list.queryOptions()),
+		queryClient.prefetchQuery(trpc.companies.options.queryOptions({ q: "" })),
+	]);
 
 	return (
 		<HydrateClient>

--- a/apps/app/lib/trpc/query-client.ts
+++ b/apps/app/lib/trpc/query-client.ts
@@ -1,17 +1,9 @@
-import {
-	defaultShouldDehydrateQuery,
-	QueryClient,
-} from "@tanstack/react-query";
+import { QueryClient } from "@tanstack/react-query";
 
 export function makeQueryClient(): QueryClient {
 	return new QueryClient({
 		defaultOptions: {
 			queries: { staleTime: 30_000 },
-			dehydrate: {
-				shouldDehydrateQuery: (query) =>
-					defaultShouldDehydrateQuery(query) ||
-					query.state.status === "pending",
-			},
 		},
 	});
 }

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -76,8 +76,9 @@ function SelectTrigger({
 function SelectContent({
 	className,
 	children,
-	position = "item-aligned",
-	align = "center",
+	position = "popper",
+	align = "start",
+	sideOffset = 4,
 	...props
 }: React.ComponentProps<typeof SelectPrimitive.Content>) {
 	return (
@@ -87,21 +88,17 @@ function SelectContent({
 				data-align-trigger={position === "item-aligned"}
 				className={cn(
 					"relative z-50 max-h-(--radix-select-content-available-height) min-w-36 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-					position === "popper" &&
-						"data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
 					className,
 				)}
 				position={position}
 				align={align}
+				sideOffset={position === "popper" ? sideOffset : undefined}
 				{...props}
 			>
 				<SelectScrollUpButton />
 				<SelectPrimitive.Viewport
 					data-position={position}
-					className={cn(
-						"data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)",
-						position === "popper" && "",
-					)}
+					className="data-[position=popper]:w-full data-[position=popper]:min-w-(--radix-select-trigger-width)"
 				>
 					{children}
 				</SelectPrimitive.Viewport>


### PR DESCRIPTION
… use Promise.all for improved performance. Update Select component alignment and position properties for better UI consistency. Remove unnecessary dehydrate options in query client configuration.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized query prefetching on Companies, Contacts, and Deals with Promise.all for faster server rendering. Simplified `@tanstack/react-query` client options and fixed Select dropdown alignment for consistent UI.

- **Refactors**
  - Prefetch page queries in parallel via Promise.all (Companies, Contacts, Deals).
  - Remove custom dehydrate options from the query client; keep `staleTime` only.

- **Bug Fixes**
  - Set Select defaults to `position="popper"`, `align="start"`, and `sideOffset=4` for consistent alignment.

<sup>Written for commit 71ba1ca92f350fef48f8abaa3066451178b43c97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

