### PR TITLE
fix: forward SheetTrigger props so create buttons open their sheets

### DIFF
--- a/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx
@@ -38,9 +38,11 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNASSIGNED = "unassigned";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+// SheetTrigger asChild clones this with onClick/ref/aria-*; spread them through
+// or the trigger is inert and the sheet never opens.
+function AddButton({ disabled, ...props }: React.ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button disabled={disabled} {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New company
 		</Button>

--- a/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx
@@ -33,9 +33,11 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const NONE = "none";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+// SheetTrigger asChild clones this with onClick/ref/aria-*; spread them through
+// or the trigger is inert and the sheet never opens.
+function AddButton({ disabled, ...props }: React.ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button disabled={disabled} {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New contact
 		</Button>

--- a/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx
@@ -40,9 +40,11 @@ import { useTRPC } from "@/lib/trpc/client";
 
 const UNSET = "";
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+// SheetTrigger asChild clones this with onClick/ref/aria-*; spread them through
+// or the trigger is inert and the sheet never opens.
+function AddButton({ disabled, ...props }: React.ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button disabled={disabled} {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			New deal
 		</Button>

--- a/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
+++ b/apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx
@@ -44,9 +44,11 @@ const EMPTY = {
 	clientSecret: "",
 };
 
-function AddButton({ disabled }: { disabled?: boolean }) {
+// SheetTrigger asChild clones this with onClick/ref/aria-*; spread them through
+// or the trigger is inert and the sheet never opens.
+function AddButton({ disabled, ...props }: React.ComponentProps<typeof Button>) {
 	return (
-		<Button disabled={disabled}>
+		<Button disabled={disabled} {...props}>
 			<Icon icon={Add} data-icon="inline-start" />
 			Add provider
 		</Button>


### PR DESCRIPTION
Every "New …" button in the app is inert on `main` (9323f21). Clicking does nothing, so there is currently no way to create a record through the UI.

## Cause

`AddButton` destructures only `disabled` and drops the rest of its props, but it is rendered inside `<SheetTrigger asChild>`:

```tsx
function AddButton({ disabled }: { disabled?: boolean }) {
  return <Button disabled={disabled}>…</Button>
}
```

`asChild` clones the child with `onClick`, `ref`, `aria-haspopup` and `data-state`. None of them reach the underlying `<button>`, so the trigger never fires.

The rendered DOM confirms it — the button has no `aria-haspopup`, no `data-state` and no `type="button"`, all of which Radix injects on a trigger:

```json
{ "data-slot": "button", "data-variant": "default", "data-size": "default", "class": "…" }
```

The tRPC layer is fine. `companies.create` succeeds when called directly, and navigating straight to `?new=true` opens the sheet and creates records normally — the mutation was simply never fired from the UI.

## Affected

| File | Button |
|---|---|
| `apps/app/app/(app)/[slug]/companies/create-company-sheet.tsx` | New company |
| `apps/app/app/(app)/[slug]/contacts/create-contact-sheet.tsx` | New contact |
| `apps/app/app/(app)/[slug]/deals/create-deal-sheet.tsx` | New deal |
| `apps/app/app/(app)/[slug]/settings/sso/add-sso-provider-sheet.tsx` | Add provider |

## Fix

Spread the remaining props onto `Button`. React 19 passes `ref` as a regular prop, so the spread carries it too.

```tsx
function AddButton({ disabled, ...props }: React.ComponentProps<typeof Button>) {
  return <Button disabled={disabled} {...props}>…</Button>
}
```

## Verification

Driven against a local instance with headless Chromium.

Before: click registered, URL unchanged, no sheet, no console errors.
After: `aria-haspopup="dialog"` present, click sets `?new=true`, sheet opens, and a company created through the form lands in Postgres. Contacts and Deals confirmed the same way.

`bun run check-types` passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forwarded `SheetTrigger` props through `AddButton` so “New …” buttons open their sheets again. Restores create flows for companies, contacts, deals, and SSO providers.

- **Bug Fixes**
  - Spread all remaining props onto `Button` to pass `onClick`, `ref`, and aria/data attrs from `SheetTrigger asChild`.
  - Updated the company, contact, deal, and SSO provider create sheets.

<sup>Written for commit 712fac308c1baa4985d0c11ac76b439290c951ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

