### PR TITLE
fix(api): print browser-ready instructions from dev:session

### DIFF
--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -62,6 +62,27 @@ await db.session.upsert({
 	update: { expiresAt },
 });
 
-console.log(`${COOKIE_NAME}=${await signCookieValue(token)}`);
+const cookieValue = await signCookieValue(token);
+const cookie = `${COOKIE_NAME}=${cookieValue}`;
+const appUrl =
+	process.env.APP_URL?.split(",")[0]?.trim() ?? "http://localhost:3000";
+
+console.log(cookie);
+console.log();
+console.log(`Signed in as ${email}. To load the session in your browser:`);
+console.log();
+console.log(`  1. Open ${appUrl}`);
+console.log(
+	"  2. Open the browser console (View → Developer → JavaScript Console)",
+);
+console.log("  3. Paste this line and press Enter:");
+console.log();
+console.log(
+	`     document.cookie = "${cookie}; path=/; max-age=${SESSION_DAYS * 24 * 60 * 60}"`,
+);
+console.log();
+console.log("  4. Reload the page.");
+console.log();
+console.log(`The session expires in ${SESSION_DAYS} days.`);
 
 await db.$disconnect();


### PR DESCRIPTION
## Why

`dev:session` minted a session and printed the cookie as `name=value`, then stopped. There was no explanation of what to do with that string, so anyone following the README was stuck looking at a wall of text and a `/sign-in` page. For a new developer this is the very first thing they hit, and it required reading the browser's cookie internals to get past it (#100).

## What

After minting the session, print clear next steps: open the app, paste a `document.cookie` assignment into the browser console, reload. The raw `name=value` cookie line is preserved first, so scripts that parse it keep working. The production guard is unchanged.

Closes #100.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prints browser-ready instructions from `dev:session` so new developers can load a session in the browser quickly (closes #100). Keeps the raw cookie output for scripts; production guard unchanged.

- **Bug Fixes**
  - After minting, prints steps: open app (`APP_URL` first value or http://localhost:3000), paste `document.cookie = "<name=value>; path=/; max-age=..."`, reload; also shows expiry. 
  - First log line remains `name=value` for tooling.

<sup>Written for commit c864c1fc4a9a245733708daf939ae89c810f8af5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

