### PR TITLE
fix(app): show select field values in record tables

### DIFF
--- a/apps/app/components/crm/fields/field-columns.tsx
+++ b/apps/app/components/crm/fields/field-columns.tsx
@@ -14,18 +14,12 @@ type WithFields = { fields: Record<string, string | number | boolean | null> };
 function render(
 	type: string,
 	value: string | number | boolean | null,
-	options: { id: string; label: string }[],
 	users: Map<string, Owner>,
 ) {
 	if (value === null || value === "") return <EmptyCellValue />;
 
 	if (type === "CHECKBOX") return value === true ? "Yes" : "No";
 	if (type === "DATE") return formatDay(String(value));
-	if (type === "SELECT") {
-		return (
-			options.find((option) => option.id === value)?.label ?? <EmptyCellValue />
-		);
-	}
 	if (type === "USER") {
 		const user = users.get(String(value));
 		return user ? <OwnerCell owner={user} /> : <EmptyCellValue />;
@@ -66,12 +60,7 @@ export function useFieldColumns<Row extends WithFields>(
 				hideBelow: "lg" as const,
 				cell: (row: Row) => (
 					<span className="truncate">
-						{render(
-							field.type,
-							row.fields[field.key] ?? null,
-							field.options,
-							byId,
-						)}
+						{render(field.type, row.fields[field.key] ?? null, byId)}
 					</span>
 				),
 			}));


### PR DESCRIPTION
Custom SELECT fields rendered as an empty cell in every record table.

`tableValuesFor` already resolves the option id to a label server-side, deliberately — `serializeField` strips archived options, and a column shared by many rows can't re-attach them per record the way `serializeFieldFor` does. The cell then looked that label up again against option ids and always missed. `fields.spec.ts:434` pins the server behaviour.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty cells for `SELECT` custom fields in record tables. We now render the label returned by the API instead of looking it up by option ID, so values (including archived options) display correctly.

<sup>Written for commit fa6ba9f41fce1296375adead36df20d2f5e29cf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

