### PR TITLE
fix(repo): make a clean clone pass its own checks on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"version": "1.11.0",
 	"scripts": {
-		"prepare": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+		"prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
 		"build": "turbo run build",
 		"dev": "turbo run dev",
 		"lint": "turbo run lint",


### PR DESCRIPTION
I found two small Windows-related issues after cloning the project today and following the quick start:

**`bun install` fails on Windows.**
The prepare script uses two redirects (`>/dev/null 2>&1`), which Bun's shell can't parse on Windows. The dependencies still install, but the command exits with an error at the end. Because of this, `core.hooksPath` isn't configured, so the pre-push hook isn't installed. The CONTRIBUTING guide says `bun install` sets this up, but that's not true on Windows. I had to use `--no-verify` to push.

**`bun run lint` fails because of Windows line endings.**
Git for Windows uses CRLF by default, while Biome expects LF. Since the repo doesn't have a `.gitattributes` file, Windows checkouts get CRLF and linting fails across `@crm/db`, `@crm/ui`, and `@crm/env`. Adding `* text=auto eol=lf` to `.gitattributes` fixes this. `git add --renormalize .` produced no changes, so this shouldn't affect existing files or macOS users—it only makes Git use LF when checking out on Windows.

I also checked the tests. `bun run test` fails on an unmodified `main` as well, so it doesn't seem related to these changes. The `bulk.spec.ts` test times out after around 5 seconds and then the test process hangs.

Separately, `bun run db:test` also fails on a clean clone because `pg` is used in `test-db.ts` but isn't listed in any package.json. Also, `test-db.ts` expects `TEST_DATABASE_URL` from `process.env`, but when running through the `packages/db` filter, Bun doesn't load the root `.env`. The existing `require-local-db.ts` already handles this correctly.

Happy to send a separate fix for the database test issues.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Windows setup: make the `prepare` script work with Bun’s shell and enforce LF checkouts so lint passes on Windows. After this, a clean clone on Windows installs Git hooks and `bun run lint` succeeds.

- Bug Fixes
  - Update `prepare` to set `core.hooksPath` without double redirects (`git config core.hooksPath .githooks 2>/dev/null || true`) so `bun install` doesn’t error on Windows.
  - Add `.gitattributes` with `* text=auto eol=lf` to ensure LF line endings on Windows and avoid Biome CRLF lint failures.

<sup>Written for commit 6f200fd9b48627731b177d51a5508892d951183a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

