### PR TITLE
fix: unblock the test suite and actually install the git hooks (CMP-83)

### DIFF
--- a/apps/api/test/bulk.spec.ts
+++ b/apps/api/test/bulk.spec.ts
@@ -134,12 +134,16 @@ describe("assigning an owner to a selection", () => {
 			email: `alan@${domain}`,
 		});
 
-		await expect(
-			contacts.bulkAssignOwner({
+		let refused: Error | null = null;
+		try {
+			await contacts.bulkAssignOwner({
 				ids: [contact.id],
 				ownerId: `nobody-${suffix}`,
-			}),
-		).rejects.toThrow(/does not work here/);
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/does not work here/);
 
 		expect(
 			await db.contact.findUnique({
@@ -224,9 +228,16 @@ describe("moving a selection of deals to a stage", () => {
 			ownerId,
 		});
 
-		await expect(
-			deals.bulkSetStage({ ids: [deal.id], stage: "CLOSED_LOST" }, ownerId),
-		).rejects.toThrow(/teaches nobody anything/);
+		let refused: Error | null = null;
+		try {
+			await deals.bulkSetStage(
+				{ ids: [deal.id], stage: "CLOSED_LOST" },
+				ownerId,
+			);
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/teaches nobody anything/);
 
 		expect(
 			await db.deal.findUnique({

--- a/apps/api/test/fields.spec.ts
+++ b/apps/api/test/fields.spec.ts
@@ -176,9 +176,13 @@ describe("field definitions", () => {
 			spec_runs_on: "AWS",
 		});
 
-		await expect(fields.update(field.id, { type: "TEXT" })).rejects.toThrow(
-			/cannot change/,
-		);
+		let refused: Error | null = null;
+		try {
+			await fields.update(field.id, { type: "TEXT" });
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/cannot change/);
 	});
 
 	it("will not turn a field into a select with nothing to choose", async () => {
@@ -194,9 +198,13 @@ describe("field definitions", () => {
 			showOnTable: false,
 		});
 
-		await expect(fields.update(field.id, { type: "SELECT" })).rejects.toThrow(
-			/at least one option/,
-		);
+		let refused: Error | null = null;
+		try {
+			await fields.update(field.id, { type: "SELECT" });
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/at least one option/);
 	});
 
 	it("archives without losing values, and restores them", async () => {
@@ -250,9 +258,13 @@ describe("field definitions", () => {
 			keys.indexOf("spec_runs_on"),
 		);
 
-		await expect(
-			fields.reorder({ entity: "CONTACT", ids: [first.id] }),
-		).rejects.toThrow(/not on this record type/);
+		let refused: Error | null = null;
+		try {
+			await fields.reorder({ entity: "CONTACT", ids: [first.id] });
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/not on this record type/);
 	});
 });
 
@@ -294,9 +306,13 @@ describe("field values", () => {
 		expect(renewal?.value).toBe("2027-03-31T12:30:00.000Z");
 
 		for (const raw of ["2027/03/31", "03-31-2027", "31 March 2027"]) {
-			await expect(
-				fields.applyValues(db, "COMPANY", record, { spec_renewal: raw }),
-			).rejects.toThrow(/takes a date/);
+			let refused: Error | null = null;
+			try {
+				await fields.applyValues(db, "COMPANY", record, { spec_renewal: raw });
+			} catch (cause) {
+				refused = cause as Error;
+			}
+			expect(refused?.message).toMatch(/takes a date/);
 		}
 
 		expect(
@@ -321,12 +337,16 @@ describe("field values", () => {
 	it("writes none of a batch when one value in it is refused", async () => {
 		const record = await makeCompany("batch");
 
-		await expect(
-			fields.applyValues(db, "COMPANY", record, {
+		let refused: Error | null = null;
+		try {
+			await fields.applyValues(db, "COMPANY", record, {
 				spec_seats: "12",
 				spec_renewal: "the spring",
-			}),
-		).rejects.toThrow(/takes a date/);
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/takes a date/);
 
 		expect(await db.fieldValue.count({ where: { companyId: record } })).toBe(0);
 	});
@@ -346,12 +366,16 @@ describe("field values", () => {
 			showOnTable: false,
 		});
 
-		await expect(
-			fields.applyValues(db, "COMPANY", record, {
+		let refused: Error | null = null;
+		try {
+			await fields.applyValues(db, "COMPANY", record, {
 				spec_seats: "12",
 				spec_champion: `nobody-${suffix}`,
-			}),
-		).rejects.toThrow(/works here/);
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/works here/);
 
 		expect(await db.fieldValue.count({ where: { companyId: record } })).toBe(0);
 
@@ -428,9 +452,13 @@ describe("a select option that was taken away", () => {
 			),
 		).toEqual(["Silver"]);
 
-		await expect(
-			fields.applyValues(db, "COMPANY", record, { spec_tier: "Gold" }),
-		).rejects.toThrow(/no option/);
+		let refused: Error | null = null;
+		try {
+			await fields.applyValues(db, "COMPANY", record, { spec_tier: "Gold" });
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused?.message).toMatch(/no option/);
 	});
 
 	it("still reads as a label in a table, not as an option id", async () => {
@@ -466,13 +494,17 @@ describe("a record update that fails", () => {
 	it("leaves a company's field values as they were", async () => {
 		const record = await makeCompany("company-rollback");
 
-		await expect(
-			companies.update(record, {
+		let refused: Error | null = null;
+		try {
+			await companies.update(record, {
 				name: "Renamed",
 				ownerId: `nobody-${suffix}`,
 				fields: { spec_seats: "99" },
-			}),
-		).rejects.toThrow();
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused).not.toBeNull();
 
 		expect(await db.fieldValue.count({ where: { companyId: record } })).toBe(0);
 	});
@@ -499,12 +531,16 @@ describe("a record update that fails", () => {
 			select: { id: true },
 		});
 
-		await expect(
-			contacts.update(contact.id, {
+		let refused: Error | null = null;
+		try {
+			await contacts.update(contact.id, {
 				companyId: `nobody-${suffix}`,
 				fields: { spec_note: "Reads the docs" },
-			}),
-		).rejects.toThrow();
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused).not.toBeNull();
 
 		expect(
 			await db.fieldValue.count({ where: { contactId: contact.id } }),
@@ -529,12 +565,16 @@ describe("a record update that fails", () => {
 			select: { id: true },
 		});
 
-		await expect(
-			deals.update(deal.id, {
+		let refused: Error | null = null;
+		try {
+			await deals.update(deal.id, {
 				companyId: `nobody-${suffix}`,
 				fields: { spec_risk: "Champion left" },
-			}),
-		).rejects.toThrow();
+			});
+		} catch (cause) {
+			refused = cause as Error;
+		}
+		expect(refused).not.toBeNull();
 
 		expect(await db.fieldValue.count({ where: { dealId: deal.id } })).toBe(0);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"license": "MIT",
 	"version": "1.13.0",
 	"scripts": {
-		"prepare": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+		"prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
 		"build": "turbo run build",
 		"dev": "turbo run dev",
 		"lint": "turbo run lint",


### PR DESCRIPTION
Two bugs found while doing other work. Both are independent of the boundary-types PRs and can merge on their own.

**`bun run test` now finishes uncached in 32 seconds across 1049 tests.** It previously never terminated.

## 1. The suite deadlocked

`bun test` never finished for `apps/api`. A test would report a 5s timeout, the remaining tests would still run, and then the *process* would not exit — so the run had to be killed. That is why every recent PR went up with `--no-verify`.

The trigger is narrow, and I checked each alternative rather than guessing:

| Hypothesis | Result |
| --- | --- |
| The exception type (Nest `HttpException`) | passes in isolation |
| Pending vs already-rejected promise | both pass |
| The regex matcher argument | passes |
| **A database write earlier in the same test** | **deadlocks** |

Every hanging case performs a service write that opens a Prisma interactive transaction — `contacts.create`, `deals.create`, `fields.create`, `fields.applyValues` — and *then* asserts with `expect(promise).rejects`. try/catch at the identical call site settles in **4ms**, against a deadlock that outlives a 60s timeout.

Eleven sites converted to the try/catch idiom the repo already uses (`agent-runs.spec.ts` is the model). Every regex matcher is preserved; the three bare `.toThrow()` sites became `expect(refused).not.toBeNull()`. **No assertion was weakened or removed.** Every remaining `.rejects` in the repo was checked for a preceding write — 25 sites, none had one, so they are left alone rather than churned.

## 2. `prepare` never ran on Windows

```diff
- "prepare": "git rev-parse --git-dir >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+ "prepare": "git config core.hooksPath .githooks 2>/dev/null || true",
```

**bun's shell accepts only one redirect per command.** `>/dev/null 2>&1` fails to parse — and so does `>/dev/null 2>/dev/null`, so it is the count, not the fd-duplication. The script exited non-zero, and bun then rolled back its `package.json` edit while keeping the lockfile, which is why `bun add` kept half-applying.

The consequence is worse than the noise: **`core.hooksPath` was never set, so the pre-push hook has not been installed for anyone on Windows.** `git config` already fails on the condition the `rev-parse` guard was testing for, so one redirect does the same job. Verified inside a repo (sets the path, exit 0, silent), outside one (exit 0, silent), and under POSIX `sh` so npm/yarn/CI are unaffected.

## Verification

- `bun run test` uncached — 10/10 tasks, **1049 tests, 32.6s**, exit 0
- `apps/api` alone — 348 pass / 0 fail / 31 files / 7.1s
- `bun run check-types` 13/13 · `bun run lint` 9/9
- **This branch was pushed with the pre-push hook enabled**, not `--no-verify` — the first one that could be.

## Worth a follow-up, not fixed here

Five `.rejects` chains are never `await`ed, so those assertions never actually run: `apps/api/test/sso.spec.ts:66` and `:70`, `apps/app/test/agent-bridge.spec.ts:78`, `apps/agent/test/custom-agent-runtime.spec.ts:304`, `apps/agent/test/slack-people.integration.spec.ts:244`. Adding `await` may surface real failures, so it belongs in its own change rather than hiding inside this one.

`apps/api/test/auth.e2e.spec.ts` flaked once during the sweep and then passed four consecutive isolated runs and every full-suite run. Its `beforeAll` boots the whole Nest `AppModule`, which can exceed the 5s default on a cold process. If it recurs the fix is an explicit timeout on that hook, not a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)