### PR TITLE
fix(build): vendor required peer deps into function bundle

### DIFF
--- a/apps/api/scripts/build-func.mjs
+++ b/apps/api/scripts/build-func.mjs
@@ -30,7 +30,15 @@ const EXTERNALS = [
 	"cardinal",
 ];
 
-const VENDOR_ROOTS = ["express", "@nestjs/swagger", "reflect-metadata"];
+const VENDOR_ROOTS = [
+	"express",
+	"@nestjs/swagger",
+	"reflect-metadata",
+	"@nestjs/common",
+	"@nestjs/core",
+	"class-transformer",
+	"class-validator",
+];
 
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(funcDir, { recursive: true });
@@ -102,7 +110,18 @@ function vendorDeps(realDir, name, placedDir) {
 	} catch {
 		return;
 	}
-	for (const depName of Object.keys(pj.dependencies || {})) {
+	const optionalPeers = new Set(
+		Object.entries(pj.peerDependenciesMeta || {})
+			.filter(([, meta]) => meta.optional)
+			.map(([depName]) => depName),
+	);
+	const depNames = new Set([
+		...Object.keys(pj.dependencies || {}),
+		...Object.keys(pj.peerDependencies || {}).filter(
+			(depName) => !optionalPeers.has(depName),
+		),
+	]);
+	for (const depName of depNames) {
 		const depReal = resolveDep(realDir, name, depName);
 		if (!depReal) {
 			console.warn(`  ! not found: ${depName} (needed by ${name})`);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serves a stable OpenAPI JSON at /openapi.json and prevents production crashes by vendoring non-optional peer dependencies required by Nest and Swagger. Previously, the function crashed with MODULE_NOT_FOUND and lacked a JSON endpoint; now the JSON spec is available and required peers are bundled.

- Configures Swagger with `{ jsonDocumentUrl: "openapi.json" }` so GET /openapi.json returns the merged spec (including the tRPC bridge schema).
- Vendors runtime peer deps by walking non-optional `peerDependencies` and adds vendor roots for `@nestjs/swagger`, `reflect-metadata`, `@nestjs/common`, `@nestjs/core`, `class-transformer`, and `class-validator`, pulling in `rxjs` as needed to avoid missing-module errors.

**Rollout**
- No migrations. Deploy and verify GET /openapi.json returns 200 with a complete document.

<sup>Written for commit 059a865170335cf1ce19fe062f32676cc773b8aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- pr-title: fix(build): vendor required peer deps into function bundle -->