### PR TITLE
fix(agent): wait for Prisma generate before dev starts

### DIFF
--- a/apps/agent/test/turbo.spec.ts
+++ b/apps/agent/test/turbo.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const turbo = readFileSync(join(import.meta.dir, "..", "turbo.json"), "utf8");
+
+const lock = "@crm/db#db:generate";
+
+describe("agent dev waits for the Prisma client", () => {
+	it("orders dev after db generate", () => {
+		const start = turbo.indexOf('"dev":');
+		const end = turbo.indexOf('"dev:headless":', start);
+		const block = turbo.slice(start, end);
+
+		expect(block).toContain(`"dependsOn": ["$TURBO_EXTENDS$", "${lock}"]`);
+	});
+
+	it("orders dev:headless after db generate", () => {
+		const start = turbo.indexOf('"dev:headless":');
+		const end = turbo.indexOf("/**", start);
+		const block = turbo.slice(start, end);
+
+		expect(block).toContain(`"dependsOn": ["$TURBO_EXTENDS$", "${lock}"]`);
+	});
+});

--- a/apps/agent/turbo.json
+++ b/apps/agent/turbo.json
@@ -10,7 +10,7 @@
 			"dependsOn": ["topo", "^build"]
 		},
 		"dev": {
-			"dependsOn": ["$TURBO_EXTENDS$"],
+			"dependsOn": ["$TURBO_EXTENDS$", "@crm/db#db:generate"],
 			"cache": false,
 			"interactive": true,
 			"persistent": true,
@@ -24,7 +24,7 @@
 			]
 		},
 		"dev:headless": {
-			"dependsOn": ["$TURBO_EXTENDS$"],
+			"dependsOn": ["$TURBO_EXTENDS$", "@crm/db#db:generate"],
 			"cache": false,
 			"persistent": true,
 			"passThroughEnv": [


### PR DESCRIPTION
## Summary

Agent `dev` and `dev:headless` now depend on `@crm/db#db:generate` so eve never bundles against a partially written Prisma client on a fresh clone.

Closes #99

## Problem

On first `bun run dev`, agent's eve bundler can read `@crm/db` while `packages/db/src/generated/prisma/` is still being written. That produces `UNRESOLVED_IMPORT` on `./internal/class` and kills the persistent dev task after app/api already look healthy.

`^dev:prepare` alone is not enough here: `prepare-dev.ts` runs migrate and generate concurrently, and turbo does not expose `db:generate` as a separate ordering edge for agent dev.

## Solution

Add `@crm/db#db:generate` to `dependsOn` for both agent dev tasks while keeping `$TURBO_EXTENDS$` so root `^dev:prepare` still applies. A small regression test in `apps/agent/test/turbo.spec.ts` locks the dependency in place.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent dev tasks now wait for Prisma generate before starting. Previously, `dev` and `dev:headless` could start while `@crm/db` was still generating, causing unresolved imports and killing the persistent dev task on fresh clones. Now both tasks depend on `@crm/db#db:generate`.

- Updated `apps/agent/turbo.json`: added `"dependsOn": ["$TURBO_EXTENDS$", "@crm/db#db:generate"]` to `dev` and `dev:headless`.
- Added `apps/agent/test/turbo.spec.ts` to lock this dependency for both tasks.
- No migration required; fresh clones may start slightly later while the Prisma client generates.

<sup>Written for commit 0fc98ec9a6cf0164f2be9fe2ec615fb10a558aca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

