### PR TITLE
fix: provide browser login snippet in dev-session

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,8 @@ Scope any of them with a Turborepo filter: `bun run dev --filter=api`.
 
 Because sign-in goes through an identity provider, there is no way to get a session from a terminal —
 `dev:session` writes the rows Better Auth would have written and prints the cookie it
-would have set. It refuses to run with `NODE_ENV=production`.
+would have set, along with a console snippet to log in directly on `http://localhost:3000`.
+It refuses to run with `NODE_ENV=production`.
 
 ## Deploying
 

--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -65,10 +65,11 @@ await db.session.upsert({
 const cookieValue = await signCookieValue(token);
 console.log(`${COOKIE_NAME}=${cookieValue}`);
 
-if (process.stdout.isTTY) {
-	console.log("\nTo sign in on http://localhost:3000:");
-	console.log("Paste this in the DevTools Console (F12) and press Enter:\n");
-	console.log(
+if (process.stderr.isTTY || process.stdout.isTTY) {
+	const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+	console.error(`\nTo sign in on ${appUrl}:`);
+	console.error("Paste this in the DevTools Console (F12) and press Enter:\n");
+	console.error(
 		`  document.cookie = "${COOKIE_NAME}=${cookieValue}; path=/; max-age=${SESSION_DAYS * 86400}"; location.href = "/";\n`,
 	);
 }

--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -65,8 +65,10 @@ await db.session.upsert({
 const cookieValue = await signCookieValue(token);
 console.log(`${COOKIE_NAME}=${cookieValue}`);
 
-if (process.stderr.isTTY || process.stdout.isTTY) {
-	const appUrl = process.env.APP_URL ?? "http://localhost:3000";
+if (process.stderr.isTTY) {
+	const appUrl = (process.env.APP_URL ?? "http://localhost:3000")
+		.split(",")[0]
+		.trim();
 	console.error(`\nTo sign in on ${appUrl}:`);
 	console.error("Paste this in the DevTools Console (F12) and press Enter:\n");
 	console.error(

--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -62,6 +62,15 @@ await db.session.upsert({
 	update: { expiresAt },
 });
 
-console.log(`${COOKIE_NAME}=${await signCookieValue(token)}`);
+const cookieValue = await signCookieValue(token);
+console.log(`${COOKIE_NAME}=${cookieValue}`);
+
+if (process.stdout.isTTY) {
+	console.log("\nTo sign in on http://localhost:3000:");
+	console.log("Paste this in the DevTools Console (F12) and press Enter:\n");
+	console.log(
+		`  document.cookie = "${COOKIE_NAME}=${cookieValue}; path=/; max-age=${SESSION_DAYS * 86400}"; location.href = "/";\n`,
+	);
+}
 
 await db.$disconnect();

--- a/apps/app/app/(landing)/sign-in/page.tsx
+++ b/apps/app/app/(landing)/sign-in/page.tsx
@@ -95,8 +95,10 @@ async function SignIn({
 
 				<p className="text-center text-muted-foreground text-sm/5">
 					Set GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET — or MICROSOFT_CLIENT_ID
-					and MICROSOFT_CLIENT_SECRET — in the root .env file and restart. Your
-					own identity provider can be added from Settings once somebody is
+					and MICROSOFT_CLIENT_SECRET — in the root .env file and restart. For
+					local development without OAuth, mint a session with{" "}
+					<code className="text-xs">bun run --filter=api dev:session</code>.
+					Your own identity provider can be added from Settings once somebody is
 					signed in.
 				</p>
 			</>

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,6 +24,10 @@ run needs `db:migrate` only for the seed that follows it. When the database and
 they do not match — reconcile with `db:migrate`, or `db:reset` when the divergence
 is an edited migration that has already been applied.
 
+When developing without Google or Microsoft OAuth configured, mint a local session
+with `bun run --filter=api dev:session` and paste the printed snippet into the
+browser DevTools Console on `http://localhost:3000` to sign in.
+
 ## Google Cloud
 
 - **Enable the Gmail API and the Google Calendar API** on the project.


### PR DESCRIPTION
Fixes #100

When running `bun run --filter=api dev:session` in local development without Google/Microsoft OAuth credentials, the script now prints a one-line DevTools Console snippet to immediately set the cookie and navigate to the app.

### What changed
1. In `apps/api/scripts/dev-session.ts`: when `process.stdout.isTTY` is true, prints a one-liner (`document.cookie = "...; path=/; max-age=..."; location.href = "/";`) for the browser DevTools console while keeping the raw cookie string intact on stdout for scripts.
2. In `apps/app/app/(landing)/sign-in/page.tsx`: added a reference to `bun run --filter=api dev:session` on the empty sign-in state when no OAuth provider is configured.
3. In `docs/setup.md` and `README.md`: documented the console login snippet under local development setup.

### Verification
- `bun run check-types` across all 10 packages passed cleanly (`FULL TURBO`).
- `bun run lint` passed with 0 errors.
- `apps/app` unit tests (169 tests) all passed.
- No code comments added; adheres strictly to repository guidelines.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DevTools-console login snippet to `dev:session` for local development without OAuth, without breaking script usage. Previously only the raw cookie printed to stdout; now, when interactive, the script prints guidance to stderr and keeps stdout machine-readable.

- `dev:session` prints the signed cookie to stdout; when `process.stderr.isTTY` it writes instructions and the browser snippet to stderr, deriving the app origin from the first `APP_URL` entry (default `http://localhost:3000`).
- The empty sign-in state now points to `bun run --filter=api dev:session`; `README.md` and `docs/setup.md` document the browser snippet.
- No production change; the command refuses to run with `NODE_ENV=production`.

<sup>Written for commit 1fa4496d69b71b5907f44f9b383245f0b31b764e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

