### PR TITLE
feat(db): add PLN to supported currencies

### DIFF
--- a/packages/db/src/currency.ts
+++ b/packages/db/src/currency.ts
@@ -17,6 +17,7 @@ const CURRENCY_LIST: readonly CurrencyMeta[] = [
 	{ code: "CHF", name: "Swiss Franc", minorUnits: 2 },
 	{ code: "HKD", name: "Hong Kong Dollar", minorUnits: 2 },
 	{ code: "SGD", name: "Singapore Dollar", minorUnits: 2 },
+	{ code: "PLN", name: "Polish Złoty", minorUnits: 2 },
 	{ code: "ZAR", name: "South African Rand", minorUnits: 2 },
 ] as const;
 

--- a/packages/db/test/currency.spec.ts
+++ b/packages/db/test/currency.spec.ts
@@ -74,6 +74,7 @@ describe("normalizeCurrency and isCurrencyCode", () => {
 			"CHF",
 			"HKD",
 			"SGD",
+			"PLN",
 			"ZAR",
 		]);
 	});


### PR DESCRIPTION
Deals sold to Polish public-sector and SMB customers are invoiced in złoty, and today an amount can't be recorded in its actual currency. The keyless rate feed (open.er-api.com) already quotes PLN, so this is just the list entry plus the spec expectation.

Currency tests, check-types, lint and lint:slop pass locally; verified on a local install (a PLN deal saves cleanly).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds PLN to the supported currencies so deals invoiced in Polish złoty can be recorded in their actual currency. The exchange rate feed already quotes PLN, so no other changes are required.

<sup>Written for commit 5f77ccf1d0c5e579b5c9911dc04b2fbf41dd3915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

