### PR TITLE
fix(api): enrol the dev session user in the workspace

### DIFF
--- a/apps/api/scripts/dev-session.ts
+++ b/apps/api/scripts/dev-session.ts
@@ -1,3 +1,4 @@
+import { ensureWorkspaceMembership } from "@crm/auth";
 import { AUTH_COOKIE_PREFIX } from "@crm/auth/cookies";
 import { db } from "@crm/db";
 
@@ -47,6 +48,8 @@ const user = await db.user.upsert({
 	update: {},
 });
 
+const workspaceId = await ensureWorkspaceMembership(user.id);
+
 const token = `dev-session-${user.id}`;
 const expiresAt = new Date(Date.now() + SESSION_DAYS * 24 * 60 * 60 * 1000);
 
@@ -58,8 +61,9 @@ await db.session.upsert({
 		userId: user.id,
 		expiresAt,
 		updatedAt: new Date(),
+		activeOrganizationId: workspaceId ?? null,
 	},
-	update: { expiresAt },
+	update: { expiresAt, activeOrganizationId: workspaceId ?? null },
 });
 
 console.log(`${COOKIE_NAME}=${await signCookieValue(token)}`);


### PR DESCRIPTION
`bun run dev:session me@example.com` mints a session that the app then rejects with
"You are not a member of this workspace." — the connections page 500s on it, and so
does anything else workspace-scoped.

The script writes the session row straight through Prisma, so better-auth's
`session.create.before` hook never runs, and that hook is what calls
`ensureWorkspaceMembership`. A brand-new dev user therefore never gets a `member` row.
It only looks like it works on a workspace that still has zero members, where the
backfill branch enrols everyone who already exists.

Two lines: call the same helper the hook calls, and carry `activeOrganizationId` the
same way it does.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev sessions so `bun run dev:session` mints sessions the app accepts. The script wrote session rows directly through Prisma, skipping the `session.create.before` hook that calls `ensureWorkspaceMembership`, so new dev users were never enrolled in a workspace and workspace-scoped calls rejected them with "You are not a member of this workspace." The script now calls the same helper and sets `activeOrganizationId` the same way the hook does.

<sup>Written for commit 1c47c66485d4b28f26415c38fa79a10defa6dc26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

