### PR TITLE
docs: propose a knowledge base the agents can read

### DIFF
--- a/adrs/knowledge-base.md
+++ b/adrs/knowledge-base.md
@@ -1,0 +1,40 @@
+# A knowledge base the agents can read
+
+Having the agents built into the CRM is awesome. They already get some context
+from the website you fill in on the settings page, and from whatever they turn up
+by web research. That is not enough.
+
+What makes a sales agent great is understanding the company's mission, its ICP,
+its full feature set, the value props for particular customers, playbooks on how
+the company wants to sell, and competitive battle cards. None of that is on our
+website, and web research cannot reach any of it. So the agents inside the CRM
+cannot possibly get any of this today. They answer questions about fit and pitch
+from whatever they can scrape, which comes out generic and off-message.
+
+I want somewhere in the CRM to put that internal knowledge. It is useful for the
+humans as well, by the way. Today it sits in whatever document the person who
+wrote it happened to use, and the rep who needs the ICP goes looking for it.
+
+## What I'd do
+
+Markdown entries at `/knowledge`. Every member reads and writes them. A shared
+team wiki that only admins can edit does not get written.
+
+Agents get `list_knowledge` and `read_knowledge`. The session preamble opens with
+an index of what exists, so the model knows to go and look before it answers
+about fit, pitch or demo. Writes only work in an attended session, so a
+dispatched research task or a deployed team agent cannot quietly rewrite the ICP
+with nobody there to check it.
+
+## What it breaks
+
+A new table and one migration. Entries are global, with no `organizationId`,
+which matches "One organization, and it is not a tenancy boundary" in
+`docs/api.md`.
+
+Entry text becomes model input, so the index escapes the markdown it emits and
+collapses whitespace. That way a title cannot open a heading or a list item.
+Nothing that exists today changes behaviour. The preamble gets one more block.
+
+I have this built and working if you want the code, but I'm leading with the
+idea.


### PR DESCRIPTION
Adding an ADR, per CONTRIBUTING.

Short version: the agents in the CRM can read the website you fill in on the settings page and do web research, but they cannot reach the internal knowledge that makes a sales agent good. The mission, the ICP, the value props for particular customers, the playbooks, the battle cards. So they answer questions about fit and pitch from whatever they can scrape, which comes out generic and off-message.

The proposal is in `adrs/knowledge-base.md`.

I have this built and running on a fork if you want the code, but I am leading with the idea.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ADR proposing a shared knowledge base for CRM agents. It addresses the gap between the public website and web research they can use today and the internal sales context needed for specific, on-message fit and pitch answers.

**Proposal**

- Store Markdown entries at `/knowledge`, with read and write access for every member.
- Give agents `list_knowledge` and `read_knowledge`, and add an escaped, whitespace-collapsed index to the session preamble.
- Allow writes only during attended sessions so dispatched tasks and deployed agents cannot modify knowledge silently.
- Add one global table and migration; existing behavior remains unchanged apart from the added preamble block.

<sup>Written for commit 9e017d1338c31128e7a8c005764c002025dd297d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

