### PR TITLE
docs: require Node 24 for the eve agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Written up where the work happens, not in a style guide:
 
 ## Quick start
 
-You need [Bun](https://bun.com) and Docker.
+You need [Bun](https://bun.com), [Node.js](https://nodejs.org) 24 or newer, and Docker. Bun runs the API and the scripts; Next.js and the eve agent run on Node.
 
 ```sh
 git clone https://github.com/trycompai/crm.git && cd crm

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"typescript": "5.9.2"
 	},
 	"engines": {
-		"node": ">=22"
+		"node": ">=24"
 	},
 	"packageManager": "bun@1.3.12",
 	"devEngines": {


### PR DESCRIPTION
## What changed

- `package.json`: `engines.node` goes from `>=22` to `>=24`.
- `README.md`: the quick start now lists Node.js 24 beside Bun and Docker, and says which runtime runs what.

## Why

eve 0.29.4, which runs the agent, refuses to start below Node 24. Next.js also needs a real Node, because Turbopack's hashed external-module aliases do not resolve under Bun's runtime. A fresh clone on a machine with only Bun fails at `bun run dev` twice, and the docs never mention Node.

## For the reviewer

Documentation only. Bun does not enforce `engines`, so the bump changes the number the next self-hoster reads, not the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the documented Node requirement to 24 and bumps `package.json` engines to match, so the quick start reflects what the eve agent actually needs.

The eve agent (0.29.4) refuses to start below Node 24, and Next.js requires a real Node runtime because Turbopack's external-module aliases don't resolve under Bun. Previously the docs only mentioned Bun and Docker, so a fresh clone could fail at `bun run dev` with no hint. Since Bun does not enforce `engines`, this changes the documented requirement, not the build.

<sup>Written for commit a770ae723cc99b475787391935915e6edc21f451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/trycompai/crm/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

